### PR TITLE
Feat/update request

### DIFF
--- a/Turner.Infrastructure.Crud.Tests/CreateRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/CreateRequestTests.cs
@@ -28,8 +28,8 @@ namespace Turner.Infrastructure.Crud.Tests
             var user = Context.Set<User>().FirstOrDefault();
             Assert.IsNotNull(user);
             Assert.AreEqual("TestUser", user.Name);
-            Assert.AreEqual("PreMessage", user.PreMessage);
-            Assert.AreEqual("PostMessage/Entity/User", user.PostMessage);
+            Assert.AreEqual(null, user.PreMessage);
+            Assert.AreEqual("PostCreate/Entity/User", user.PostMessage);
         }
 
         [Test]
@@ -49,8 +49,8 @@ namespace Turner.Infrastructure.Crud.Tests
             var user = Context.Set<User>().FirstOrDefault();
             Assert.IsNotNull(user);
             Assert.AreEqual("TestUser", user.Name);
-            Assert.AreEqual("PreMessage", user.PreMessage);
-            Assert.AreEqual("PostMessage/Entity/User", user.PostMessage);
+            Assert.AreEqual(null, user.PreMessage);
+            Assert.AreEqual("PostCreate/Entity/User", user.PostMessage);
         }
 
         [Test]
@@ -68,8 +68,8 @@ namespace Turner.Infrastructure.Crud.Tests
             Assert.IsNotNull(response.Data);
             Assert.AreEqual("TestUser", response.Data.Name);
             Assert.AreEqual(response.Data.Id, Context.Set<User>().First().Id);
-            Assert.AreEqual("PreMessage/Entity/User", response.Data.PreMessage);
-            Assert.AreEqual("PostMessage/Entity", response.Data.PostMessage);
+            Assert.AreEqual("PreCreate/Entity/User", response.Data.PreMessage);
+            Assert.AreEqual("PostCreate/Entity", response.Data.PostMessage);
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace Turner.Infrastructure.Crud.Tests
             var user = Context.Set<User>().FirstOrDefault();
             Assert.IsNotNull(user);
             Assert.AreEqual("TestUser", user.Name);
-            Assert.AreEqual("PreMessage", user.PreMessage);
+            Assert.AreEqual(null, user.PreMessage);
             Assert.AreEqual("Default", user.PostMessage);
         }
 
@@ -103,8 +103,8 @@ namespace Turner.Infrastructure.Crud.Tests
             Assert.IsNotNull(response.Data);
             Assert.AreEqual("TestUser", response.Data.Name);
             Assert.AreEqual(response.Data.Id, Context.Set<User>().First().Id);
-            Assert.AreEqual("PreMessage", response.Data.PreMessage);
-            Assert.AreEqual("PostMessage/Entity", response.Data.PostMessage);
+            Assert.AreEqual(null, response.Data.PreMessage);
+            Assert.AreEqual("PostCreate/Entity", response.Data.PostMessage);
         }
     }
 

--- a/Turner.Infrastructure.Crud.Tests/Fakes/FakeEntities.cs
+++ b/Turner.Infrastructure.Crud.Tests/Fakes/FakeEntities.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using System;
 using System.ComponentModel.DataAnnotations;
 
 namespace Turner.Infrastructure.Crud.Tests.Fakes
@@ -52,9 +53,35 @@ namespace Turner.Infrastructure.Crud.Tests.Fakes
         }
     }
 
-    public class Site : Entity
+    public class Site : Entity, IHasPreMessage
     {
+        [Required]
+        public Guid Guid { get; set; }
 
+        public string PreMessage { get; set; }
+    }
+
+    public class SiteDto : IHasPreMessage
+    {
+        public Guid Guid { get; set; }
+
+        public string PreMessage { get; set; }
+    }
+
+    public class SiteGetDto : SiteDto
+    {
+        public int Id { get; set; }
+
+        public string PostMessage { get; set; }
+    }
+
+    public class SiteProfiles : Profile
+    {
+        public SiteProfiles()
+        {
+            CreateMap<SiteDto, Site>()
+                .ForMember(x => x.Id, o => o.Ignore());
+        }
     }
 
     public class NonEntity

--- a/Turner.Infrastructure.Crud.Tests/Fakes/FakeEntities.cs
+++ b/Turner.Infrastructure.Crud.Tests/Fakes/FakeEntities.cs
@@ -33,7 +33,7 @@ namespace Turner.Infrastructure.Crud.Tests.Fakes
     {
         public string Name { get; set; }
 
-        public string PreMessage { get; set; } = "PreMessage";
+        public string PreMessage { get; set; }
     }
     
     public class UserGetDto : UserDto

--- a/Turner.Infrastructure.Crud.Tests/Fakes/Profiles.cs
+++ b/Turner.Infrastructure.Crud.Tests/Fakes/Profiles.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using Turner.Infrastructure.Crud.Configuration;
+﻿using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 
 namespace Turner.Infrastructure.Crud.Tests.Fakes

--- a/Turner.Infrastructure.Crud.Tests/Fakes/Profiles.cs
+++ b/Turner.Infrastructure.Crud.Tests/Fakes/Profiles.cs
@@ -1,4 +1,6 @@
-﻿using Turner.Infrastructure.Crud.Configuration;
+﻿using System;
+using System.Linq.Expressions;
+using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 
 namespace Turner.Infrastructure.Crud.Tests.Fakes
@@ -27,6 +29,28 @@ namespace Turner.Infrastructure.Crud.Tests.Fakes
             {
                 config.FailedToFindInAnyIsError = true;
             });
+        }
+    }
+
+    public class DefaultGetRequestProfile<TEntity, TKey, TOut> 
+        : CrudRequestProfile<GetRequest<TEntity, TKey, TOut>>
+        where TEntity : class, IEntity
+    {
+        public DefaultGetRequestProfile()
+        {
+            ForEntity<IEntity>()
+                .SelectForGetWith(builder => builder.Build("Key", "Id"));
+        }
+    }
+
+    public class DefaultUpdateRequestProfile<TEntity, TKey, TIn, TOut>
+        : CrudRequestProfile<UpdateRequest<TEntity, TKey, TIn, TOut>>
+        where TEntity : class, IEntity
+    {
+        public DefaultUpdateRequestProfile()
+        {
+            ForEntity<IEntity>()
+                .SelectForUpdateWith(builder => builder.Build(r => r.Key, e => e.Id));
         }
     }
 }

--- a/Turner.Infrastructure.Crud.Tests/Fakes/Profiles.cs
+++ b/Turner.Infrastructure.Crud.Tests/Fakes/Profiles.cs
@@ -8,12 +8,21 @@ namespace Turner.Infrastructure.Crud.Tests.Fakes
     {
         public CrudRequestProfile()
         {
+            BeforeCreating(request =>
+            {
+                if (request is IHasPreMessage tRequest)
+                    tRequest.PreMessage = "PreCreate";
+            });
+
+            BeforeUpdating(request =>
+            {
+                if (request is IHasPreMessage tRequest)
+                    tRequest.PreMessage = "PreUpdate";
+            });
+
             ForEntity<IEntity>()
-                .AfterCreating(entity =>
-                {
-                    entity.PostMessage = "PostMessage/Entity";
-                    return Task.CompletedTask;
-                });
+                .AfterCreating(entity => entity.PostMessage = "PostCreate/Entity")
+                .AfterUpdating(entity => entity.PostMessage = "PostUpdate/Entity");
 
             ConfigureErrors(config =>
             {

--- a/Turner.Infrastructure.Crud.Tests/Fakes/Profiles.cs
+++ b/Turner.Infrastructure.Crud.Tests/Fakes/Profiles.cs
@@ -17,7 +17,7 @@ namespace Turner.Infrastructure.Crud.Tests.Fakes
 
             ConfigureErrors(config =>
             {
-                config.FailedToFindIsError = true;
+                config.FailedToFindInAnyIsError = true;
             });
         }
     }

--- a/Turner.Infrastructure.Crud.Tests/Fakes/Profiles.cs
+++ b/Turner.Infrastructure.Crud.Tests/Fakes/Profiles.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq.Expressions;
-using Turner.Infrastructure.Crud.Configuration;
+﻿using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 
 namespace Turner.Infrastructure.Crud.Tests.Fakes

--- a/Turner.Infrastructure.Crud.Tests/GetRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/GetRequestTests.cs
@@ -123,26 +123,21 @@ namespace Turner.Infrastructure.Crud.Tests
         public GetByIdRequest(int id) : base(id) { }
     }
 
+    public class GetByIdRequestProfile<TEntity, TOut>
+        : CrudRequestProfile<GetByIdRequest<TEntity, TOut>>
+        where TEntity : class, IEntity
+    {
+        public GetByIdRequestProfile()
+        {
+            ForEntity<IEntity>()
+                .SelectForGetWith(builder => builder.Build("Key", "Id"));
+        }
+    }
+
     [DoNotValidate]
     public class GetUserByNameRequest : IGetRequest<User, UserGetDto>
     {
         public string Name { get; set; }
-    }
-
-    public class GetRequestProfile<TEntity, TOut> : CrudRequestProfile<IGetRequest<TEntity, TOut>>
-        where TEntity : class, IEntity
-    {
-        public GetRequestProfile()
-        {
-            ForEntity<IEntity>()
-                .SelectForGetWith(request =>
-                {
-                    if (request is GetRequest<TEntity, int, TOut> intRequest)
-                        return entity => intRequest.Data == entity.Id;
-
-                    return null;
-                });
-        }
     }
 
     public class GetUserByIdProfile : CrudRequestProfile<GetUserByIdRequest>

--- a/Turner.Infrastructure.Crud.Tests/GetRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/GetRequestTests.cs
@@ -22,6 +22,8 @@ namespace Turner.Infrastructure.Crud.Tests
             _site = new Site { Guid = Guid.NewGuid() };
 
             Context.Add(_user);
+            Context.Add(_site);
+
             Context.SaveChanges();
         }
 

--- a/Turner.Infrastructure.Crud.Tests/GetRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/GetRequestTests.cs
@@ -137,7 +137,7 @@ namespace Turner.Infrastructure.Crud.Tests
         public GetRequestProfile()
         {
             ForEntity<IEntity>()
-                .SelectWith(request =>
+                .SelectForGetWith(request =>
                 {
                     if (request is GetRequest<TEntity, int, TOut> intRequest)
                         return entity => intRequest.Data == entity.Id;
@@ -152,7 +152,7 @@ namespace Turner.Infrastructure.Crud.Tests
         public GetUserByIdProfile()
         {
             ForEntity<User>()
-                .SelectWith(r => e => e.Id == r.Id)
+                .SelectForAnyWith(r => e => e.Id == r.Id)
                 .UseDefault(new User { Name = "DefaultUser" });
         }
     }
@@ -163,10 +163,10 @@ namespace Turner.Infrastructure.Crud.Tests
         {
             ForEntity<User>()
                 .UseDefault(new User { Name = "DefaultUser" })
-                .SelectWith(request => entity =>
+                .SelectForGetWith(request => entity =>
                     string.Equals(entity.Name, request.Name, StringComparison.InvariantCultureIgnoreCase));
 
-            ConfigureErrors(config => config.FailedToFindIsError = false);
+            ConfigureErrors(config => config.FailedToFindInGetIsError = false);
         }
     }
 }

--- a/Turner.Infrastructure.Crud.Tests/GetRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/GetRequestTests.cs
@@ -1,12 +1,10 @@
 ﻿using NUnit.Framework;
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Errors;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Mediator;
 using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Tests

--- a/Turner.Infrastructure.Crud.Tests/GetRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/GetRequestTests.cs
@@ -13,11 +13,13 @@ namespace Turner.Infrastructure.Crud.Tests
     public class GetRequestTests : BaseUnitTest
     {
         User _user;
+        Site _site;
 
         [SetUp]
         public void SetUp()
         {
             _user = new User { Name = "TestUser" };
+            _site = new Site { Guid = Guid.NewGuid() };
 
             Context.Add(_user);
             Context.SaveChanges();
@@ -35,6 +37,20 @@ namespace Turner.Infrastructure.Crud.Tests
             Assert.AreEqual(_user.Name, response.Data.Name);
             Assert.AreEqual(_user.PreMessage, response.Data.PreMessage);
             Assert.AreEqual(_user.PostMessage, response.Data.PostMessage);
+        }
+
+        [Test]
+        public async Task Handle_GenericGetByGuidRequest_GetsSite()
+        {
+            var request = new GetByGuidRequest<Site, SiteGetDto>(_site.Guid);
+            var response = await Mediator.HandleAsync(request);
+
+            Assert.IsFalse(response.HasErrors);
+            Assert.IsNotNull(response.Data);
+            Assert.AreEqual(_site.Id, response.Data.Id);
+            Assert.AreEqual(_site.Guid, response.Data.Guid);
+            Assert.AreEqual(_site.PreMessage, response.Data.PreMessage);
+            Assert.AreEqual(_site.PostMessage, response.Data.PostMessage);
         }
 
         [Test]
@@ -117,23 +133,6 @@ namespace Turner.Infrastructure.Crud.Tests
         public int Id { get; set; }
     }
     
-    public class GetByIdRequest<TEntity, TOut> : GetRequest<TEntity, int, TOut>
-        where TEntity : class, IEntity
-    {
-        public GetByIdRequest(int id) : base(id) { }
-    }
-
-    public class GetByIdRequestProfile<TEntity, TOut>
-        : CrudRequestProfile<GetByIdRequest<TEntity, TOut>>
-        where TEntity : class, IEntity
-    {
-        public GetByIdRequestProfile()
-        {
-            ForEntity<IEntity>()
-                .SelectForGetWith(builder => builder.Build("Key", "Id"));
-        }
-    }
-
     [DoNotValidate]
     public class GetUserByNameRequest : IGetRequest<User, UserGetDto>
     {

--- a/Turner.Infrastructure.Crud.Tests/Turner.Infrastructure.Crud.Tests.csproj
+++ b/Turner.Infrastructure.Crud.Tests/Turner.Infrastructure.Crud.Tests.csproj
@@ -19,6 +19,10 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Deploy|AnyCPU'">
     <DefineConstants>TRACE;DEPLOY;NETCOREAPP2_0</DefineConstants>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <None Remove="Turner.Infrastructure.Crud.Tests.v3.ncrunchproject" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.2" />

--- a/Turner.Infrastructure.Crud.Tests/UpdateRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/UpdateRequestTests.cs
@@ -41,7 +41,7 @@ namespace Turner.Infrastructure.Crud.Tests
             Assert.IsNotNull(response.Data);
             Assert.AreEqual(_user.Id, response.Data.Id);
             Assert.AreEqual("NewName", response.Data.Name);
-            Assert.AreEqual("PreMessage/Update", response.Data.PreMessage);
+            Assert.AreEqual("PreUpdate/Update", response.Data.PreMessage);
             Assert.AreEqual("PostMessage/Update", response.Data.PostMessage);
         }
 

--- a/Turner.Infrastructure.Crud.Tests/UpdateRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/UpdateRequestTests.cs
@@ -7,7 +7,6 @@ using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Errors;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Mediator;
 using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Tests

--- a/Turner.Infrastructure.Crud.Tests/UpdateRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/UpdateRequestTests.cs
@@ -1,0 +1,209 @@
+﻿using AutoMapper;
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Errors;
+using Turner.Infrastructure.Crud.Requests;
+using Turner.Infrastructure.Crud.Tests.Fakes;
+using Turner.Infrastructure.Mediator;
+using Turner.Infrastructure.Mediator.Decorators;
+
+namespace Turner.Infrastructure.Crud.Tests
+{
+    [TestFixture]
+    public class UpdateRequestTests : BaseUnitTest
+    {
+        User _user;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _user = new User { Name = "TestUser" };
+
+            Context.Add(_user);
+            Context.SaveChanges();
+        }
+
+        [Test]
+        public async Task Handle_UpdateUserByIdRequest_UpdatesUser()
+        {
+            var request = new UpdateUserByIdRequest
+            {
+                Id = _user.Id,
+                Name = "NewName"
+            };
+
+            var response = await Mediator.HandleAsync(request);
+
+            Assert.IsFalse(response.HasErrors);
+            Assert.IsNotNull(response.Data);
+            Assert.AreEqual(_user.Id, response.Data.Id);
+            Assert.AreEqual("NewName", response.Data.Name);
+            Assert.AreEqual("PreMessage/Update", response.Data.PreMessage);
+            Assert.AreEqual("PostMessage/Update", response.Data.PostMessage);
+        }
+
+        [Test]
+        public async Task Handle_UpdateUserByNameRequest_UpdatesUser()
+        {
+            var request = new UpdateUserByNameRequest
+            {
+                Name = _user.Name,
+                Data = new UserDto { Name = "NewName" }
+            };
+
+            var response = await Mediator.HandleAsync(request);
+
+            Assert.IsFalse(response.HasErrors);
+            var user = Context.Set<User>().FirstOrDefault();
+            Assert.NotNull(user);
+            Assert.AreEqual(_user.Id, user.Id);
+            Assert.AreEqual("NewName", user.Name);
+            Assert.AreEqual(_user.PreMessage, user.PreMessage);
+            Assert.AreEqual(_user.PostMessage, user.PostMessage);
+        }
+
+        [Test]
+        public async Task Handle_InvalidUpdateUserByNameRequest_ThrowsException()
+        {
+            FailedToFindException error = null;
+
+            var request = new UpdateUserByNameRequest { Name = "NonUser", Data = new UserDto() };
+
+            try
+            {
+                await Mediator.HandleAsync(request);
+            }
+            catch (FailedToFindException e)
+            {
+                error = e;
+            }
+
+            Assert.IsNotNull(error);
+        }
+
+        [Test]
+        public async Task Handle_InvalidUpdateUserByIdRequest_ReturnsNull()
+        {
+            var request = new UpdateUserByIdRequest { Id = 100, Name = string.Empty };
+            var response = await Mediator.HandleAsync(request);
+
+            Assert.IsFalse(response.HasErrors);
+            Assert.IsNull(response.Data);
+        }
+
+        [Test]
+        public async Task Handle_DefaultUpdateWithoutResponseRequest_UpdatesUser()
+        {
+            var request = new UpdateRequest<User, UserGetDto>(new UserGetDto
+            {
+                Id = _user.Id,
+                Name = "NewUser"
+            });
+
+            var response = await Mediator.HandleAsync(request);
+
+            Assert.IsFalse(response.HasErrors);
+            var user = Context.Set<User>().First();
+            Assert.IsNotNull(user);
+            Assert.AreEqual(_user.Id, user.Id);
+            Assert.AreEqual(_user.Name, user.Name);
+            Assert.AreEqual(_user.PreMessage, user.PreMessage);
+            Assert.AreEqual(_user.PostMessage, user.PostMessage);
+        }
+
+        [Test]
+        public async Task Handle_DefaultUpdateWithResponseRequest_UpdatesUser()
+        {
+            var request = new UpdateRequest<User, UserGetDto, UserGetDto>(new UserGetDto
+            {
+                Id = _user.Id,
+                Name = "NewUser"
+            });
+
+            var response = await Mediator.HandleAsync(request);
+
+            Assert.IsFalse(response.HasErrors);
+            Assert.IsNotNull(response.Data);
+            Assert.AreEqual(_user.Id, response.Data.Id);
+            Assert.AreEqual(_user.Name, response.Data.Name);
+            Assert.AreEqual(_user.PreMessage, response.Data.PreMessage);
+            Assert.AreEqual(_user.PostMessage, response.Data.PostMessage);
+        }
+    }
+    
+    [DoNotValidate]
+    public class UpdateUserByIdRequest 
+        : UserDto, IUpdateRequest<User, UserGetDto>
+    {
+        public int Id { get; set; }
+    }
+
+    [DoNotValidate]
+    public class UpdateUserByNameRequest
+        : IUpdateRequest<User>
+    {
+        public string Name { get; set; }
+        public UserDto Data { get; set; }
+    }
+
+    public class UpdateRequestProfile<TEntity, TOut> 
+        : CrudRequestProfile<IUpdateRequest<TEntity, TOut>>
+        where TEntity : class, IEntity
+    {
+        public UpdateRequestProfile()
+        {
+            ForEntity<IEntity>()
+                .AfterUpdating(entity => entity.PostMessage = "PostMessage");
+        }
+    }
+
+    public class UpdateUserWithoutResponseRequestProfile 
+        : CrudRequestProfile<UpdateRequest<User, UserGetDto>>
+    {
+        public UpdateUserWithoutResponseRequestProfile()
+        {
+            ForEntity<User>()
+                .SelectForUpdateWith(request => entity => request.Data.Id == entity.Id);
+        }
+    }
+
+    public class UpdateUserWithResponseRequestProfile 
+        : CrudRequestProfile<UpdateRequest<User, UserGetDto, UserGetDto>>
+    {
+        public UpdateUserWithResponseRequestProfile()
+        {
+            ForEntity<User>()
+                .SelectForUpdateWith(request => entity => request.Data.Id == entity.Id);
+        }
+    }
+
+    public class UpdateUserByIdProfile : CrudRequestProfile<UpdateUserByIdRequest>
+    {
+        public UpdateUserByIdProfile()
+        {
+            ForEntity<User>()
+                .SelectForUpdateWith(request => entity => entity.Id == request.Id)
+                .BeforeUpdating(request => request.PreMessage += "/Update")
+                .AfterUpdating(entity => entity.PostMessage += "/Update");
+
+            ConfigureErrors(config => config.FailedToFindInUpdateIsError = false);
+        }
+    }
+
+    public class UpdateUserByNameProfile : CrudRequestProfile<UpdateUserByNameRequest>
+    {
+        public UpdateUserByNameProfile()
+        {
+            ForEntity<User>()
+                .SelectForAnyWith(request => entity =>
+                    string.Equals(entity.Name, request.Name, StringComparison.InvariantCultureIgnoreCase))
+                .UpdateWith((request, entity) => 
+                    Task.FromResult(Mapper.Map(request.Data, entity)));
+
+            ConfigureErrors(config => config.FailedToFindInUpdateIsError = true);
+        }
+    }
+}

--- a/Turner.Infrastructure.Crud.Tests/UpdateRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/UpdateRequestTests.cs
@@ -131,6 +131,23 @@ namespace Turner.Infrastructure.Crud.Tests
             Assert.AreEqual(_user.PreMessage, response.Data.PreMessage);
             Assert.AreEqual(_user.PostMessage, response.Data.PostMessage);
         }
+        
+        [Test]
+        public async Task Handle_UpdateRequestWithBuiltSelector_UpdatesUser()
+        {
+            var request = new UpdateRequest<User, int, UserDto, UserGetDto>(
+                _user.Id, 
+                new UserDto { Name = "NewUser" });
+
+            var response = await Mediator.HandleAsync(request);
+
+            Assert.IsFalse(response.HasErrors);
+            Assert.IsNotNull(response.Data);
+            Assert.AreEqual(_user.Id, response.Data.Id);
+            Assert.AreEqual(_user.Name, response.Data.Name);
+            Assert.AreEqual(_user.PreMessage, response.Data.PreMessage);
+            Assert.AreEqual(_user.PostMessage, response.Data.PostMessage);
+        }
     }
     
     [DoNotValidate]

--- a/Turner.Infrastructure.Crud/Algorithms/ContextAccess.cs
+++ b/Turner.Infrastructure.Crud/Algorithms/ContextAccess.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System.Threading.Tasks;
+
+namespace Turner.Infrastructure.Crud.Algorithms
+{
+    public interface IContextAccess
+    {
+        DbSet<TEntity> GetEntities<TEntity>(DbContext context)
+            where TEntity : class;
+
+        Task ApplyChangesAsync(DbContext context);
+    }
+
+    public class StandardContextAccess : IContextAccess
+    {
+        public DbSet<TEntity> GetEntities<TEntity>(DbContext context)
+            where TEntity : class
+        {
+            return context.Set<TEntity>();
+        }
+
+        public async Task ApplyChangesAsync(DbContext context)
+        {
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/Turner.Infrastructure.Crud/Algorithms/ContextAccess.cs
+++ b/Turner.Infrastructure.Crud/Algorithms/ContextAccess.cs
@@ -21,7 +21,7 @@ namespace Turner.Infrastructure.Crud.Algorithms
 
         public async Task ApplyChangesAsync(DbContext context)
         {
-            await context.SaveChangesAsync();
+            await context.SaveChangesAsync().Configure();
         }
     }
 }

--- a/Turner.Infrastructure.Crud/Algorithms/DbSetAccess.cs
+++ b/Turner.Infrastructure.Crud/Algorithms/DbSetAccess.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Turner.Infrastructure.Crud.Algorithms
+{
+    public interface IDbSetAccess
+    {
+        TEntity Create<TEntity>(TEntity entity, DbSet<TEntity> set)
+            where TEntity : class;
+
+        Task<TEntity> CreateAsync<TEntity>(TEntity entity, 
+            DbSet<TEntity> set, 
+            CancellationToken token = default(CancellationToken))
+            where TEntity : class;
+    }
+
+    public class StandardDbSetAccess : IDbSetAccess
+    {
+        public TEntity Create<TEntity>(TEntity entity, DbSet<TEntity> set)
+            where TEntity : class
+        {
+            return set.Add(entity).Entity;
+        }
+
+        public async Task<TEntity> CreateAsync<TEntity>(TEntity entity, 
+            DbSet<TEntity> set,
+            CancellationToken token = default(CancellationToken))
+            where TEntity : class
+        {
+            var trackedEntity = await set.AddAsync(entity, token);
+            return trackedEntity.Entity;
+        }
+    }
+}

--- a/Turner.Infrastructure.Crud/Algorithms/DbSetAccess.cs
+++ b/Turner.Infrastructure.Crud/Algorithms/DbSetAccess.cs
@@ -28,7 +28,7 @@ namespace Turner.Infrastructure.Crud.Algorithms
             CancellationToken token = default(CancellationToken))
             where TEntity : class
         {
-            var trackedEntity = await set.AddAsync(entity, token);
+            var trackedEntity = await set.AddAsync(entity, token).Configure();
             return trackedEntity.Entity;
         }
     }

--- a/Turner.Infrastructure.Crud/Configuration/Builders/CrudRequestEntityConfigBuilder.cs
+++ b/Turner.Infrastructure.Crud/Configuration/Builders/CrudRequestEntityConfigBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using Turner.Infrastructure.Crud.Utilities;
 
 namespace Turner.Infrastructure.Crud.Configuration.Builders
 {
@@ -144,10 +145,28 @@ namespace Turner.Infrastructure.Crud.Configuration.Builders
             return this;
         }
 
+        public CrudRequestEntityConfigBuilder<TRequest, TEntity> SelectForGetWith(
+            Func<SelectorBuilder<TRequest, TEntity>, Func<TRequest, Expression<Func<TEntity, bool>>>> build)
+        {
+            var builder = new SelectorBuilder<TRequest, TEntity>();
+            _selectEntityFromRequestForGet = Selector.From(build(builder));
+
+            return this;
+        }
+
         public CrudRequestEntityConfigBuilder<TRequest, TEntity> SelectForUpdateWith(
             Func<TRequest, Expression<Func<TEntity, bool>>> selector)
         {
             _selectEntityFromRequestForUpdate = Selector.From(selector);
+
+            return this;
+        }
+
+        public CrudRequestEntityConfigBuilder<TRequest, TEntity> SelectForUpdateWith(
+            Func<SelectorBuilder<TRequest, TEntity>, Func<TRequest, Expression<Func<TEntity, bool>>>> build)
+        {
+            var builder = new SelectorBuilder<TRequest, TEntity>();
+            _selectEntityFromRequestForUpdate = Selector.From(build(builder));
 
             return this;
         }

--- a/Turner.Infrastructure.Crud/Configuration/Builders/CrudRequestErrorConfig.cs
+++ b/Turner.Infrastructure.Crud/Configuration/Builders/CrudRequestErrorConfig.cs
@@ -1,7 +1,29 @@
-﻿namespace Turner.Infrastructure.Crud.Configuration.Builders
+﻿using System.Linq;
+
+namespace Turner.Infrastructure.Crud.Configuration.Builders
 {
     public class CrudRequestErrorConfig
     {
-        public bool? FailedToFindIsError { get; set; }
+        public bool? FailedToFindInGetIsError { get; set; }
+
+        public bool? FailedToFindInUpdateIsError { get; set; }
+
+        public bool? FailedToFindInAnyIsError
+        {
+            get
+            {
+                return new[]
+                {
+                    FailedToFindInGetIsError,
+                    FailedToFindInUpdateIsError
+                }.Any(x => x.HasValue && x.Value);
+            }
+
+            set
+            {
+                FailedToFindInGetIsError = 
+                FailedToFindInUpdateIsError = value;
+            }
+        }
     }
 }

--- a/Turner.Infrastructure.Crud/Configuration/CrudConfigManager.cs
+++ b/Turner.Infrastructure.Crud/Configuration/CrudConfigManager.cs
@@ -83,7 +83,7 @@ namespace Turner.Infrastructure.Crud.Configuration
                 profiles.Add((CrudRequestProfile) Activator.CreateInstance(
                     typeof(DefaultCrudRequestProfile<>).MakeGenericType(tRequest)));
             }
-
+            
             profiles.AddRange(new[] { tRequest.BaseType }
                 .Concat(tRequest.GetInterfaces())
                 .Where(x => x != null && typeof(ICrudRequest).IsAssignableFrom(x))

--- a/Turner.Infrastructure.Crud/Configuration/CrudRequestConfig.cs
+++ b/Turner.Infrastructure.Crud/Configuration/CrudRequestConfig.cs
@@ -9,12 +9,19 @@ namespace Turner.Infrastructure.Crud.Configuration
 {
     public interface ICrudRequestConfig
     {
-        bool FailedToFindIsError { get; }
+        bool FailedToFindInGetIsError { get; }
+        bool FailedToFindInUpdateIsError { get; }
 
         ISelector GetSelector<TEntity>()
             where TEntity : class;
 
-        TEntity CreateEntity<TEntity>(object request)
+        ISelector UpdateSelector<TEntity>()
+            where TEntity : class;
+
+        Task<TEntity> CreateEntity<TEntity>(object request)
+            where TEntity : class;
+
+        Task UpdateEntity<TEntity>(object request, TEntity entity)
             where TEntity : class;
 
         TEntity GetDefault<TEntity>()
@@ -25,47 +32,85 @@ namespace Turner.Infrastructure.Crud.Configuration
 
         Task PostCreate<TEntity>(TEntity entity)
             where TEntity : class;
+
+        Task PreUpdate<TEntity>(object request)
+            where TEntity : class;
+
+        Task PostUpdate<TEntity>(TEntity entity)
+            where TEntity : class;
     }
 
     public class CrudRequestConfig<TRequest>
         : ICrudRequestConfig
     {
-        private readonly Dictionary<Type, ISelector> _entitySelectors
+        private readonly Dictionary<Type, ISelector> _entityGetSelectors
             = new Dictionary<Type, ISelector>();
 
-        private readonly Dictionary<Type, Func<object, object>> _entityCreators
-            = new Dictionary<Type, Func<object, object>>();
+        private readonly Dictionary<Type, ISelector> _entityUpdateSelectors
+            = new Dictionary<Type, ISelector>();
+
+        private readonly Dictionary<Type, Func<object, Task<object>>> _entityCreators
+            = new Dictionary<Type, Func<object, Task<object>>>();
+
+        private readonly Dictionary<Type, Func<object, object, Task>> _entityUpdators
+            = new Dictionary<Type, Func<object, object, Task>>();
 
         private readonly Dictionary<Type, object> _defaultValues
             = new Dictionary<Type, object>();
 
+        // TODO: move these into a utility class
         private readonly Dictionary<Type, List<Func<object, Task>>> _entityPreCreateActions
             = new Dictionary<Type, List<Func<object, Task>>>();
 
         private readonly Dictionary<Type, List<Func<object, Task>>> _entityPostCreateActions
             = new Dictionary<Type, List<Func<object, Task>>>();
 
+        private readonly Dictionary<Type, List<Func<object, Task>>> _entityPreUpdateActions
+            = new Dictionary<Type, List<Func<object, Task>>>();
+
+        private readonly Dictionary<Type, List<Func<object, Task>>> _entityPostUpdateActions
+            = new Dictionary<Type, List<Func<object, Task>>>();
+
         public CrudRequestConfig()
         {
-            FailedToFindIsError = true;
+            FailedToFindInGetIsError = true;
+            FailedToFindInUpdateIsError = true;
         }
 
-        internal void SetFailedToFindIsError(bool isError)
+        internal void SetFailedToFindInGetIsError(bool isError)
         {
-            FailedToFindIsError = isError;
+            FailedToFindInGetIsError = isError;
         }
 
-        internal void SetEntitySelector<TEntity>(ISelector selector)
+        internal void SetFailedToFindInUpdateIsError(bool isError)
+        {
+            FailedToFindInUpdateIsError = isError;
+        }
+
+        internal void SetEntitySelectorForGet<TEntity>(ISelector selector)
             where TEntity : class
         {
-            _entitySelectors[typeof(TEntity)] = selector;
+            _entityGetSelectors[typeof(TEntity)] = selector;
+        }
+
+        internal void SetEntitySelectorForUpdate<TEntity>(ISelector selector)
+            where TEntity : class
+        {
+            _entityUpdateSelectors[typeof(TEntity)] = selector;
         }
 
         internal void SetEntityCreator<TEntity>(
-            Func<object, TEntity> creator)
+            Func<object, Task<TEntity>> creator)
             where TEntity : class
         {
-            _entityCreators[typeof(TEntity)] = request => creator(request);
+            _entityCreators[typeof(TEntity)] = async request => await creator(request);
+        }
+
+        internal void SetEntityUpdator<TEntity>(
+            Func<object, TEntity, Task> updator)
+            where TEntity : class
+        {
+            _entityUpdators[typeof(TEntity)] = (request, entity) => updator(request, (TEntity) entity);
         }
 
         internal void SetDefault<TEntity>(
@@ -89,7 +134,23 @@ namespace Turner.Infrastructure.Crud.Configuration
             _entityPostCreateActions[typeof(TEntity)] = actions;
         }
 
-        public bool FailedToFindIsError { get; private set; }
+        internal void SetPreUpdateActions<TEntity>(
+            List<Func<object, Task>> actions)
+            where TEntity : class
+        {
+            _entityPreUpdateActions[typeof(TEntity)] = actions;
+        }
+
+        internal void SetPostUpdateActions<TEntity>(
+            List<Func<object, Task>> actions)
+            where TEntity : class
+        {
+            _entityPostUpdateActions[typeof(TEntity)] = actions;
+        }
+
+        public bool FailedToFindInGetIsError { get; private set; }
+
+        public bool FailedToFindInUpdateIsError { get; private set; }
 
         public ISelector GetSelector<TEntity>()
             where TEntity : class
@@ -99,15 +160,31 @@ namespace Turner.Infrastructure.Crud.Configuration
 
             foreach (var tEntity in entities)
             {
-                if (_entitySelectors.TryGetValue(tEntity, out var selector))
+                if (_entityGetSelectors.TryGetValue(tEntity, out var selector))
                     return selector;
             }
 
             throw new BadCrudConfigurationException(
-                $"No selector defined for entity '{typeof(TEntity)}'.");
+                $"No selector defined for entity '{typeof(TEntity)}' for request '{typeof(TRequest)}'.");
         }
-        
-        public TEntity CreateEntity<TEntity>(object request)
+
+        public ISelector UpdateSelector<TEntity>()
+            where TEntity : class
+        {
+            var entities = new List<Type>();
+            BuildEntityQueue(typeof(TEntity), ref entities);
+
+            foreach (var tEntity in entities)
+            {
+                if (_entityUpdateSelectors.TryGetValue(tEntity, out var selector))
+                    return selector;
+            }
+
+            throw new BadCrudConfigurationException(
+                $"No selector defined for entity '{typeof(TEntity)}' for request '{typeof(TRequest)}'.");
+        }
+
+        public async Task<TEntity> CreateEntity<TEntity>(object request)
             where TEntity : class
         {
             if (!(request is TRequest))
@@ -121,9 +198,30 @@ namespace Turner.Infrastructure.Crud.Configuration
             }
 
             if (_entityCreators.TryGetValue(typeof(TEntity), out var creator))
-                return (TEntity) creator(request);
+                return (TEntity) await creator(request);
             
             return Mapper.Map<TEntity>(request);
+        }
+
+        public Task UpdateEntity<TEntity>(object request, TEntity entity)
+            where TEntity : class
+        {
+            if (!(request is TRequest))
+            {
+                var message =
+                    $"Unable to update an entity of type '{typeof(TEntity)}' " +
+                    $"from a request of type '{request.GetType()}'. " +
+                    $"Configuration expected a request of type '{typeof(TRequest)}'.";
+
+                throw new BadCrudConfigurationException(message);
+            }
+
+            if (_entityUpdators.TryGetValue(typeof(TEntity), out var updator))
+                return updator(request, entity);
+        
+            Mapper.Map(request, entity);
+
+            return Task.CompletedTask;
         }
 
         public TEntity GetDefault<TEntity>()
@@ -176,6 +274,47 @@ namespace Turner.Infrastructure.Crud.Configuration
             }
         }
 
+        public async Task PreUpdate<TEntity>(object request)
+            where TEntity : class
+        {
+            if (!(request is TRequest))
+            {
+                var message =
+                    $"Unable to run PreUpdate actions on a request of type '{request.GetType()}'. " +
+                    $"Configuration expected a request of type '{typeof(TRequest)}'.";
+
+                throw new BadCrudConfigurationException(message);
+            }
+
+            var entities = new List<Type>();
+            BuildEntityStack(typeof(TEntity), ref entities);
+
+            foreach (var tEntity in entities)
+            {
+                if (_entityPreUpdateActions.TryGetValue(tEntity, out var actions))
+                {
+                    foreach (var action in actions)
+                        await action(request);
+                }
+            }
+        }
+
+        public async Task PostUpdate<TEntity>(TEntity entity)
+            where TEntity : class
+        {
+            var entities = new List<Type>();
+            BuildEntityStack(typeof(TEntity), ref entities);
+
+            foreach (var tEntity in entities)
+            {
+                if (_entityPostUpdateActions.TryGetValue(tEntity, out var actions))
+                {
+                    foreach (var action in actions)
+                        await action(entity);
+                }
+            }
+        }
+        
         private void BuildEntityStack(Type tEntity, ref List<Type> entities)
         {
             var entityParents = new[] { tEntity.BaseType }

--- a/Turner.Infrastructure.Crud/Configuration/CrudRequestConfig.cs
+++ b/Turner.Infrastructure.Crud/Configuration/CrudRequestConfig.cs
@@ -109,7 +109,7 @@ namespace Turner.Infrastructure.Crud.Configuration
             Func<object, Task<TEntity>> creator)
             where TEntity : class
         {
-            _entityCreators[typeof(TEntity)] = async request => await creator(request);
+            _entityCreators[typeof(TEntity)] = async request => await creator(request).Configure();
         }
 
         internal void SetEntityUpdator<TEntity>(
@@ -216,7 +216,7 @@ namespace Turner.Infrastructure.Crud.Configuration
             }
 
             if (_entityCreators.TryGetValue(typeof(TEntity), out var creator))
-                return (TEntity) await creator(request);
+                return (TEntity) await creator(request).Configure();
             
             return Mapper.Map<TEntity>(request);
         }
@@ -264,7 +264,7 @@ namespace Turner.Infrastructure.Crud.Configuration
             }
 
             foreach (var requestAction in _preCreateActions)
-                await requestAction(request);
+                await requestAction(request).Configure();
 
             var entities = new List<Type>();
             BuildEntityStack(typeof(TEntity), ref entities);
@@ -274,7 +274,7 @@ namespace Turner.Infrastructure.Crud.Configuration
                 if (_entityPreCreateActions.TryGetValue(tEntity, out var actions))
                 {
                     foreach (var action in actions)
-                        await action(request);
+                        await action(request).Configure();
                 }
             }
         }
@@ -290,7 +290,7 @@ namespace Turner.Infrastructure.Crud.Configuration
                 if (_entityPostCreateActions.TryGetValue(tEntity, out var actions))
                 {
                     foreach (var action in actions)
-                        await action(entity);
+                        await action(entity).Configure();
                 }
             }
         }
@@ -308,7 +308,7 @@ namespace Turner.Infrastructure.Crud.Configuration
             }
 
             foreach (var requestAction in _preUpdateActions)
-                await requestAction(request);
+                await requestAction(request).Configure();
 
             var entities = new List<Type>();
             BuildEntityStack(typeof(TEntity), ref entities);
@@ -318,7 +318,7 @@ namespace Turner.Infrastructure.Crud.Configuration
                 if (_entityPreUpdateActions.TryGetValue(tEntity, out var actions))
                 {
                     foreach (var action in actions)
-                        await action(request);
+                        await action(request).Configure();
                 }
             }
         }
@@ -334,7 +334,7 @@ namespace Turner.Infrastructure.Crud.Configuration
                 if (_entityPostUpdateActions.TryGetValue(tEntity, out var actions))
                 {
                     foreach (var action in actions)
-                        await action(entity);
+                        await action(entity).Configure();
                 }
             }
         }

--- a/Turner.Infrastructure.Crud/Configuration/CrudRequestProfile.cs
+++ b/Turner.Infrastructure.Crud/Configuration/CrudRequestProfile.cs
@@ -74,8 +74,11 @@ namespace Turner.Infrastructure.Crud.Configuration
             var errorConfig = new CrudRequestErrorConfig();
             _errorConfig?.Invoke(errorConfig);
 
-            if (errorConfig.FailedToFindIsError.HasValue)
-                config.SetFailedToFindIsError(errorConfig.FailedToFindIsError.Value);
+            if (errorConfig.FailedToFindInGetIsError.HasValue)
+                config.SetFailedToFindInGetIsError(errorConfig.FailedToFindInGetIsError.Value);
+
+            if (errorConfig.FailedToFindInUpdateIsError.HasValue)
+                config.SetFailedToFindInUpdateIsError(errorConfig.FailedToFindInUpdateIsError.Value);
         }
     }
 

--- a/Turner.Infrastructure.Crud/Configuration/CrudRequestProfile.cs
+++ b/Turner.Infrastructure.Crud/Configuration/CrudRequestProfile.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration.Builders;
 using Turner.Infrastructure.Crud.Errors;
 
@@ -12,7 +13,7 @@ namespace Turner.Infrastructure.Crud.Configuration
         
         internal abstract void Inherit(IEnumerable<CrudRequestProfile> profile);
         internal abstract void Apply(ICrudRequestConfig config);
-        internal abstract void Apply<TRequest>(CrudRequestConfig<TRequest> config);
+        internal abstract void Apply<TRequest>(CrudRequestConfig<TRequest> config, ref List<Type> inherited);
     }
     
     public abstract class CrudRequestProfile<TRequest> 
@@ -23,6 +24,12 @@ namespace Turner.Infrastructure.Crud.Configuration
 
         private readonly List<CrudRequestProfile> _inheritProfiles 
             = new List<CrudRequestProfile>();
+
+        private readonly List<Func<object, Task>> _preCreateActions
+            = new List<Func<object, Task>>();
+
+        private readonly List<Func<object, Task>> _preUpdateActions
+            = new List<Func<object, Task>>();
 
         private Action<CrudRequestErrorConfig> _errorConfig;
 
@@ -41,7 +48,39 @@ namespace Turner.Infrastructure.Crud.Configuration
 
             return builder;
         }
+
+        protected void BeforeCreating(Func<TRequest, Task> preCreateAction)
+        {
+            if (preCreateAction != null)
+                _preCreateActions.Add(request => preCreateAction((TRequest) request));
+        }
+
+        protected void BeforeCreating(Action<TRequest> preCreateAction)
+        {
+            if (preCreateAction != null)
+                _preCreateActions.Add(request =>
+                {
+                    preCreateAction((TRequest) request);
+                    return Task.CompletedTask;
+                });
+        }
         
+        protected void BeforeUpdating(Func<TRequest, Task> preUpdateAction)
+        {
+            if (preUpdateAction != null)
+                _preUpdateActions.Add(request => preUpdateAction((TRequest) request));
+        }
+
+        protected void BeforeUpdating(Action<TRequest> preUpdateAction)
+        {
+            if (preUpdateAction != null)
+                _preUpdateActions.Add(request =>
+                {
+                    preUpdateAction((TRequest) request);
+                    return Task.CompletedTask;
+                });
+        }
+
         internal override void Inherit(IEnumerable<CrudRequestProfile> profiles)
         {
             _inheritProfiles.AddRange(profiles);
@@ -55,13 +94,25 @@ namespace Turner.Infrastructure.Crud.Configuration
                 throw new BadCrudConfigurationException(message);
             }
 
-            Apply(tConfig);
+            var inherited = new List<Type>();
+
+            Apply(tConfig, ref inherited);
         }
 
-        internal override void Apply<TPerspective>(CrudRequestConfig<TPerspective> config)
+        internal override void Apply<TPerspective>(CrudRequestConfig<TPerspective> config, ref List<Type> inherited)
         {
-            foreach (var profile in _inheritProfiles.Distinct())
-                profile.Apply(config);
+            foreach (var profile in _inheritProfiles)
+            {
+                if (inherited.Contains(profile.RequestType))
+                    continue;
+
+                inherited.Add(profile.RequestType);
+
+                profile.Apply(config, ref inherited);
+            }
+
+            config.AddPreCreateActions(_preCreateActions);
+            config.AddPreUpdateActions(_preUpdateActions);
 
             ApplyErrorConfig(config);
 

--- a/Turner.Infrastructure.Crud/Configuration/SimpleInjectorCrudConfiguration.cs
+++ b/Turner.Infrastructure.Crud/Configuration/SimpleInjectorCrudConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using SimpleInjector;
 using System.Collections.Generic;
 using System.Reflection;
+using Turner.Infrastructure.Crud.Algorithms;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Mediator;
 
@@ -22,20 +23,24 @@ namespace Turner.Infrastructure.Crud.Configuration
             container.RegisterSingleton(() => new CrudConfigManager(configAssemblies));
             
             bool IfNotHandled(PredicateContext c) => !c.Handled;
-            
-            container.Register(typeof(CreateRequestHandler<,>), configAssemblies);
-            container.RegisterConditional(typeof(IRequestHandler<>), typeof(CreateRequestHandler<,>), IfNotHandled);
 
+            container.RegisterConditional(typeof(IContextAccess), typeof(StandardContextAccess), IfNotHandled);
+            container.RegisterConditional(typeof(IDbSetAccess), typeof(StandardDbSetAccess), IfNotHandled);
+
+            container.RegisterConditional(typeof(ICreateAlgorithm), typeof(StandardCreateAlgorithm), IfNotHandled);
+            container.Register(typeof(CreateRequestHandler<,>), configAssemblies);
             container.Register(typeof(CreateRequestHandler<,,>), configAssemblies);
+            container.RegisterConditional(typeof(IRequestHandler<>), typeof(CreateRequestHandler<,>), IfNotHandled);
             container.RegisterConditional(typeof(IRequestHandler<,>), typeof(CreateRequestHandler<,,>), IfNotHandled);
 
+            container.RegisterConditional(typeof(IGetAlgorithm), typeof(StandardGetAlgorithm), IfNotHandled);
             container.Register(typeof(GetRequestHandler<,,>), configAssemblies);
             container.RegisterConditional(typeof(IRequestHandler<,>), typeof(GetRequestHandler<,,>), IfNotHandled);
 
+            container.RegisterConditional(typeof(IUpdateAlgorithm), typeof(StandardUpdateAlgorithm), IfNotHandled);
             container.Register(typeof(UpdateRequestHandler<,>), configAssemblies);
-            container.RegisterConditional(typeof(IRequestHandler<>), typeof(UpdateRequestHandler<,>), IfNotHandled);
-
             container.Register(typeof(UpdateRequestHandler<,,>), configAssemblies);
+            container.RegisterConditional(typeof(IRequestHandler<>), typeof(UpdateRequestHandler<,>), IfNotHandled);
             container.RegisterConditional(typeof(IRequestHandler<,>), typeof(UpdateRequestHandler<,,>), IfNotHandled);
 
         }

--- a/Turner.Infrastructure.Crud/Configuration/SimpleInjectorCrudConfiguration.cs
+++ b/Turner.Infrastructure.Crud/Configuration/SimpleInjectorCrudConfiguration.cs
@@ -31,6 +31,13 @@ namespace Turner.Infrastructure.Crud.Configuration
 
             container.Register(typeof(GetRequestHandler<,,>), configAssemblies);
             container.RegisterConditional(typeof(IRequestHandler<,>), typeof(GetRequestHandler<,,>), IfNotHandled);
+
+            container.Register(typeof(UpdateRequestHandler<,>), configAssemblies);
+            container.RegisterConditional(typeof(IRequestHandler<>), typeof(UpdateRequestHandler<,>), IfNotHandled);
+
+            container.Register(typeof(UpdateRequestHandler<,,>), configAssemblies);
+            container.RegisterConditional(typeof(IRequestHandler<,>), typeof(UpdateRequestHandler<,,>), IfNotHandled);
+
         }
     }
 }

--- a/Turner.Infrastructure.Crud/Requests/CreateRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/CreateRequestHandler.cs
@@ -1,18 +1,57 @@
 ﻿using AutoMapper;
 using Microsoft.EntityFrameworkCore;
 using System.Threading.Tasks;
+using Turner.Infrastructure.Crud.Algorithms;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Mediator;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
+    public interface ICreateAlgorithm
+    {
+        Task<TEntity> CreateEntityAsync<TEntity>(DbContext context, TEntity entity)
+            where TEntity : class;
+
+        Task SaveChangesAsync(DbContext context);
+    }
+
+    public class StandardCreateAlgorithm : ICreateAlgorithm
+    {
+        private readonly IContextAccess _contextAccess;
+        private readonly IDbSetAccess _setAccess;
+
+        public StandardCreateAlgorithm(IContextAccess contextAccess, 
+            IDbSetAccess setAccess)
+        {
+            _contextAccess = contextAccess;
+            _setAccess = setAccess;
+        }
+
+        public Task<TEntity> CreateEntityAsync<TEntity>(DbContext context, TEntity entity)
+            where TEntity : class
+        {
+            var set = _contextAccess.GetEntities<TEntity>(context);
+            return _setAccess.CreateAsync(entity, set);
+        }
+
+        public Task SaveChangesAsync(DbContext context)
+        {
+            return _contextAccess.ApplyChangesAsync(context);
+        }
+    }
+
     internal abstract class CreateRequestHandlerBase<TRequest, TEntity>
         : CrudRequestHandler<TRequest>
         where TEntity : class
     {
-        public CreateRequestHandlerBase(DbContext context, CrudConfigManager profileManager)
+        protected readonly ICreateAlgorithm Algorithm;
+
+        public CreateRequestHandlerBase(DbContext context, 
+            CrudConfigManager profileManager,
+            ICreateAlgorithm algorithm)
             : base(context, profileManager)
         {
+            Algorithm = algorithm;
         }
 
         protected async Task<TEntity> CreateEntity(TRequest request)
@@ -20,10 +59,10 @@ namespace Turner.Infrastructure.Crud.Requests
             await RequestConfig.PreCreate<TEntity>(request);
 
             var entity = await RequestConfig.CreateEntity<TEntity>(request);
-            await Context.Set<TEntity>().AddAsync(entity);
+            var newEntity = await Algorithm.CreateEntityAsync(Context, entity);
 
             await RequestConfig.PostCreate(entity);
-            await Context.SaveChangesAsync();
+            await Algorithm.SaveChangesAsync(Context);
 
             return entity;
         }
@@ -35,8 +74,10 @@ namespace Turner.Infrastructure.Crud.Requests
         where TEntity : class
         where TRequest : ICreateRequest<TEntity>
     {
-        public CreateRequestHandler(DbContext context, CrudConfigManager profileManager)
-            : base(context, profileManager)
+        public CreateRequestHandler(DbContext context, 
+            CrudConfigManager profileManager,
+            ICreateAlgorithm algorithm)
+            : base(context, profileManager, algorithm)
         {
         }
 
@@ -54,8 +95,10 @@ namespace Turner.Infrastructure.Crud.Requests
         where TEntity : class
         where TRequest : ICreateRequest<TEntity, TOut>
     {
-        public CreateRequestHandler(DbContext context, CrudConfigManager profileManager)
-            : base(context, profileManager)
+        public CreateRequestHandler(DbContext context, 
+            CrudConfigManager profileManager,
+            ICreateAlgorithm algorithm)
+            : base(context, profileManager, algorithm)
         {
         }
 

--- a/Turner.Infrastructure.Crud/Requests/CreateRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/CreateRequestHandler.cs
@@ -56,13 +56,13 @@ namespace Turner.Infrastructure.Crud.Requests
 
         protected async Task<TEntity> CreateEntity(TRequest request)
         {
-            await RequestConfig.PreCreate<TEntity>(request);
+            await RequestConfig.PreCreate<TEntity>(request).Configure();
 
-            var entity = await RequestConfig.CreateEntity<TEntity>(request);
-            var newEntity = await Algorithm.CreateEntityAsync(Context, entity);
+            var entity = await RequestConfig.CreateEntity<TEntity>(request).Configure();
+            var newEntity = await Algorithm.CreateEntityAsync(Context, entity).Configure();
 
-            await RequestConfig.PostCreate(entity);
-            await Algorithm.SaveChangesAsync(Context);
+            await RequestConfig.PostCreate(entity).Configure();
+            await Algorithm.SaveChangesAsync(Context).Configure();
 
             return entity;
         }
@@ -83,7 +83,7 @@ namespace Turner.Infrastructure.Crud.Requests
 
         public async Task<Response> HandleAsync(TRequest request)
         {
-            await CreateEntity(request);
+            await CreateEntity(request).Configure();
 
             return Response.Success();
         }
@@ -104,7 +104,7 @@ namespace Turner.Infrastructure.Crud.Requests
 
         public async Task<Response<TOut>> HandleAsync(TRequest request)
         {
-            var entity = await CreateEntity(request);
+            var entity = await CreateEntity(request).Configure();
             var result = Mapper.Map<TOut>(entity);
 
             return new Response<TOut> { Data = result };

--- a/Turner.Infrastructure.Crud/Requests/CreateRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/CreateRequestHandler.cs
@@ -7,22 +7,19 @@ using Turner.Infrastructure.Mediator;
 namespace Turner.Infrastructure.Crud.Requests
 {
     internal abstract class CreateRequestHandlerBase<TRequest, TEntity>
+        : CrudRequestHandler<TRequest>
         where TEntity : class
     {
-        protected readonly DbContext Context;
-        protected readonly ICrudRequestConfig RequestConfig;
-
         public CreateRequestHandlerBase(DbContext context, CrudConfigManager profileManager)
+            : base(context, profileManager)
         {
-            Context = context;
-            RequestConfig = profileManager.GetRequestConfigFor<TRequest>();
         }
 
         protected async Task<TEntity> CreateEntity(TRequest request)
         {
             await RequestConfig.PreCreate<TEntity>(request);
 
-            var entity = RequestConfig.CreateEntity<TEntity>(request);
+            var entity = await RequestConfig.CreateEntity<TEntity>(request);
             await Context.Set<TEntity>().AddAsync(entity);
 
             await RequestConfig.PostCreate(entity);

--- a/Turner.Infrastructure.Crud/Requests/CrudRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/CrudRequestHandler.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Turner.Infrastructure.Crud.Configuration;
+
+namespace Turner.Infrastructure.Crud.Requests
+{
+    internal abstract class CrudRequestHandler<TRequest>
+    {
+        protected readonly DbContext Context;
+        protected readonly ICrudRequestConfig RequestConfig;
+
+        protected CrudRequestHandler(DbContext context, CrudConfigManager profileManager)
+        {
+            Context = context;
+            RequestConfig = profileManager.GetRequestConfigFor<TRequest>();
+        }
+    }
+}

--- a/Turner.Infrastructure.Crud/Requests/GetRequest.cs
+++ b/Turner.Infrastructure.Crud/Requests/GetRequest.cs
@@ -14,15 +14,15 @@ namespace Turner.Infrastructure.Crud.Requests
     }
     
     [DoNotValidate]
-    public class GetRequest<TEntity, TIn, TOut> : IGetRequest<TEntity, TOut>
+    public class GetRequest<TEntity, TKey, TOut> : IGetRequest<TEntity, TOut>
         where TEntity : class
     {
-        public GetRequest(TIn data) { Data = data; }
-        public TIn Data { get; }
+        public GetRequest(TKey key) { Key = key; }
+        public TKey Key { get; }
     }
 
-    public class GetRequestProfile<TEntity, TIn, TOut>
-        : CrudRequestProfile<GetRequest<TEntity, TIn, TOut>>
+    public class GetRequestProfile<TEntity, TKey, TOut>
+        : CrudRequestProfile<GetRequest<TEntity, TKey, TOut>>
         where TEntity : class
     {
         public GetRequestProfile()

--- a/Turner.Infrastructure.Crud/Requests/GetRequest.cs
+++ b/Turner.Infrastructure.Crud/Requests/GetRequest.cs
@@ -1,4 +1,5 @@
-﻿using Turner.Infrastructure.Crud.Configuration;
+﻿using System;
+using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Mediator;
 using Turner.Infrastructure.Mediator.Decorators;
 
@@ -25,8 +26,42 @@ namespace Turner.Infrastructure.Crud.Requests
         : CrudRequestProfile<GetRequest<TEntity, TKey, TOut>>
         where TEntity : class
     {
-        public GetRequestProfile()
+        public GetRequestProfile() { }
+    }
+
+    [DoNotValidate]
+    public class GetByIdRequest<TEntity, TOut> : GetRequest<TEntity, int, TOut>
+        where TEntity : class
+    {
+        public GetByIdRequest(int id) : base(id) { }
+    }
+
+    public class GetByIdRequestProfile<TEntity, TOut>
+        : CrudRequestProfile<GetByIdRequest<TEntity, TOut>>
+        where TEntity : class
+    {
+        public GetByIdRequestProfile()
         {
+            ForEntity<TEntity>()
+                .SelectForGetWith(builder => builder.Build("Key", "Id"));
+        }
+    }
+
+    [DoNotValidate]
+    public class GetByGuidRequest<TEntity, TOut> : GetRequest<TEntity, Guid, TOut>
+        where TEntity : class
+    {
+        public GetByGuidRequest(Guid guid) : base(guid) { }
+    }
+
+    public class GetByGuidRequestProfile<TEntity, TOut>
+        : CrudRequestProfile<GetByGuidRequest<TEntity, TOut>>
+        where TEntity : class
+    {
+        public GetByGuidRequestProfile()
+        {
+            ForEntity<TEntity>()
+                .SelectForGetWith(builder => builder.Build("Key", "Guid"));
         }
     }
 }

--- a/Turner.Infrastructure.Crud/Requests/GetRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/GetRequestHandler.cs
@@ -49,7 +49,8 @@ namespace Turner.Infrastructure.Crud.Requests
         {
             var selector = RequestConfig.GetSelector<TEntity>();
             var entity = await Algorithm.GetEntities<TEntity>(Context)
-                .SelectAsync(request, selector);
+                .SelectAsync(request, selector)
+                .Configure();
 
             var failedToFind = entity == null;
             

--- a/Turner.Infrastructure.Crud/Requests/GetRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/GetRequestHandler.cs
@@ -8,17 +8,13 @@ using Turner.Infrastructure.Mediator;
 namespace Turner.Infrastructure.Crud.Requests
 {
     internal class GetRequestHandler<TRequest, TEntity, TOut>
-        : IRequestHandler<TRequest, TOut>
+        : CrudRequestHandler<TRequest>, IRequestHandler<TRequest, TOut>
         where TEntity : class
         where TRequest : IGetRequest<TEntity, TOut>
     {
-        protected readonly DbContext Context;
-        protected readonly ICrudRequestConfig RequestConfig;
-
         public GetRequestHandler(DbContext context, CrudConfigManager profileManager)
+            : base(context, profileManager)
         {
-            Context = context;
-            RequestConfig = profileManager.GetRequestConfigFor<TRequest>();
         }
 
         public async Task<Response<TOut>> HandleAsync(TRequest request)
@@ -34,7 +30,7 @@ namespace Turner.Infrastructure.Crud.Requests
                 
             var result = Mapper.Map<TOut>(entity);
 
-            if (failedToFind && RequestConfig.FailedToFindIsError)
+            if (failedToFind && RequestConfig.FailedToFindInGetIsError)
             {
                 throw new FailedToFindException("Failed to find entity.")
                 {

--- a/Turner.Infrastructure.Crud/Requests/UpdateRequest.cs
+++ b/Turner.Infrastructure.Crud/Requests/UpdateRequest.cs
@@ -1,0 +1,60 @@
+﻿using AutoMapper;
+using System.Threading.Tasks;
+using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Mediator;
+using Turner.Infrastructure.Mediator.Decorators;
+
+namespace Turner.Infrastructure.Crud.Requests
+{
+    public interface IUpdateRequest : ICrudRequest
+    {
+    }
+
+    public interface IUpdateRequest<TEntity> : IUpdateRequest, IRequest
+        where TEntity : class
+    {
+    }
+
+    public interface IUpdateRequest<TEntity, TOut> : IUpdateRequest, IRequest<TOut>
+        where TEntity : class
+    {
+    }
+
+    [DoNotValidate]
+    public class UpdateRequest<TEntity, TIn> : IUpdateRequest<TEntity>
+        where TEntity : class
+    {
+        public UpdateRequest(TIn data) { Data = data; }
+        public TIn Data { get; }
+    }
+
+    public class UpdateRequestProfile<TEntity, TIn>
+        : CrudRequestProfile<UpdateRequest<TEntity, TIn>>
+        where TEntity : class
+    {
+        public UpdateRequestProfile()
+        {
+            ForEntity<TEntity>()
+                .UpdateWith((request, entity) => Mapper.Map(request.Data, entity));
+        }
+    }
+
+    [DoNotValidate]
+    public class UpdateRequest<TEntity, TIn, TOut> : IUpdateRequest<TEntity, TOut>
+        where TEntity : class
+    {
+        public UpdateRequest(TIn data) { Data = data; }
+        public TIn Data { get; }
+    }
+
+    public class UpdateRequestProfile<TEntity, TIn, TOut>
+        : CrudRequestProfile<UpdateRequest<TEntity, TIn, TOut>>
+        where TEntity : class
+    {
+        public UpdateRequestProfile()
+        {
+            ForEntity<TEntity>()
+                .UpdateWith((request, entity) => Mapper.Map(request.Data, entity));
+        }
+    }
+}

--- a/Turner.Infrastructure.Crud/Requests/UpdateRequest.cs
+++ b/Turner.Infrastructure.Crud/Requests/UpdateRequest.cs
@@ -1,4 +1,6 @@
 ﻿using AutoMapper;
+using System;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Mediator;
@@ -19,7 +21,7 @@ namespace Turner.Infrastructure.Crud.Requests
         where TEntity : class
     {
     }
-
+    
     [DoNotValidate]
     public class UpdateRequest<TEntity, TIn> : IUpdateRequest<TEntity>
         where TEntity : class
@@ -49,6 +51,32 @@ namespace Turner.Infrastructure.Crud.Requests
 
     public class UpdateRequestProfile<TEntity, TIn, TOut>
         : CrudRequestProfile<UpdateRequest<TEntity, TIn, TOut>>
+        where TEntity : class
+    {
+        public UpdateRequestProfile()
+        {
+            ForEntity<TEntity>()
+                .UpdateWith((request, entity) => Mapper.Map(request.Data, entity));
+        }
+    }
+
+    [DoNotValidate]
+    public class UpdateRequest<TEntity, TKey, TIn, TOut> 
+        : IUpdateRequest<TEntity, TOut>
+        where TEntity : class
+    {
+        public UpdateRequest(TKey key, TIn data)
+        {
+            Key = key;
+            Data = data;
+        }
+
+        public TKey Key { get; }
+        public TIn Data { get; }
+    }
+
+    public class UpdateRequestProfile<TEntity, TKey, TIn, TOut>
+        : CrudRequestProfile<UpdateRequest<TEntity, TKey, TIn, TOut>>
         where TEntity : class
     {
         public UpdateRequestProfile()

--- a/Turner.Infrastructure.Crud/Requests/UpdateRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/UpdateRequestHandler.cs
@@ -55,7 +55,8 @@ namespace Turner.Infrastructure.Crud.Requests
         {
             var selector = RequestConfig.UpdateSelector<TEntity>();
             var entity = await Algorithm.GetEntities<TEntity>(Context)
-                .SelectAsync(request, selector);
+                .SelectAsync(request, selector)
+                .Configure();
             
             if (entity == null && RequestConfig.FailedToFindInUpdateIsError)
             {
@@ -71,11 +72,11 @@ namespace Turner.Infrastructure.Crud.Requests
 
         protected async Task UpdateEntity(TRequest request, TEntity entity)
         {
-            await RequestConfig.PreUpdate<TEntity>(request);
-            await RequestConfig.UpdateEntity(request, entity);
-            await RequestConfig.PostUpdate(entity);
+            await RequestConfig.PreUpdate<TEntity>(request).Configure();
+            await RequestConfig.UpdateEntity(request, entity).Configure();
+            await RequestConfig.PostUpdate(entity).Configure();
 
-            await Algorithm.SaveChangesAsync(Context);
+            await Algorithm.SaveChangesAsync(Context).Configure();
         }
     }
 
@@ -94,9 +95,9 @@ namespace Turner.Infrastructure.Crud.Requests
 
         public async Task<Response> HandleAsync(TRequest request)
         {
-            var entity = await GetEntity(request);
+            var entity = await GetEntity(request).Configure();
             if (entity != null)
-                await UpdateEntity(request, entity);
+                await UpdateEntity(request, entity).Configure();
 
             return Response.Success();
         }
@@ -117,12 +118,12 @@ namespace Turner.Infrastructure.Crud.Requests
 
         public async Task<Response<TOut>> HandleAsync(TRequest request)
         {
-            var entity = await GetEntity(request);
+            var entity = await GetEntity(request).Configure();
             TOut result = default(TOut);
 
             if (entity != null)
             {
-                await UpdateEntity(request, entity);
+                await UpdateEntity(request, entity).Configure();
                 result = Mapper.Map<TOut>(entity);
             }
 

--- a/Turner.Infrastructure.Crud/Requests/UpdateRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/UpdateRequestHandler.cs
@@ -1,0 +1,95 @@
+﻿using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using System.Threading.Tasks;
+using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Errors;
+using Turner.Infrastructure.Mediator;
+
+namespace Turner.Infrastructure.Crud.Requests
+{
+    internal abstract class UpdateRequestHandlerBase<TRequest, TEntity>
+        : CrudRequestHandler<TRequest>
+        where TEntity : class
+    {
+        public UpdateRequestHandlerBase(DbContext context, CrudConfigManager profileManager)
+            : base(context, profileManager)
+        {
+        }
+
+        protected async Task<TEntity> GetEntity(TRequest request)
+        {
+            var selector = RequestConfig.UpdateSelector<TEntity>();
+            var entity = await Context.Set<TEntity>()
+                .SelectAsync(request, selector);
+            
+            if (entity == null && RequestConfig.FailedToFindInUpdateIsError)
+            {
+                throw new FailedToFindException("Failed to find entity.")
+                {
+                    RequestTypeProperty = request.GetType(),
+                    QueryTypeProperty = typeof(TEntity)
+                };
+            }
+
+            return entity;
+        }
+
+        protected async Task UpdateEntity(TRequest request, TEntity entity)
+        {
+            await RequestConfig.PreUpdate<TEntity>(request);
+
+            await RequestConfig.UpdateEntity(request, entity);
+
+            await RequestConfig.PostUpdate(entity);
+
+            await Context.SaveChangesAsync();
+        }
+    }
+
+    internal class UpdateRequestHandler<TRequest, TEntity>
+        : UpdateRequestHandlerBase<TRequest, TEntity>,
+          IRequestHandler<TRequest>
+        where TEntity : class
+        where TRequest : IUpdateRequest<TEntity>
+    {
+        public UpdateRequestHandler(DbContext context, CrudConfigManager profileManager)
+            : base(context, profileManager)
+        {
+        }
+
+        public async Task<Response> HandleAsync(TRequest request)
+        {
+            var entity = await GetEntity(request);
+            if (entity != null)
+                await UpdateEntity(request, entity);
+
+            return Response.Success();
+        }
+    }
+
+    internal class UpdateRequestHandler<TRequest, TEntity, TOut>
+        : UpdateRequestHandlerBase<TRequest, TEntity>,
+          IRequestHandler<TRequest, TOut>
+        where TEntity : class
+        where TRequest : IUpdateRequest<TEntity, TOut>
+    {
+        public UpdateRequestHandler(DbContext context, CrudConfigManager profileManager)
+            : base(context, profileManager)
+        {
+        }
+
+        public async Task<Response<TOut>> HandleAsync(TRequest request)
+        {
+            var entity = await GetEntity(request);
+            TOut result = default(TOut);
+
+            if (entity != null)
+            {
+                await UpdateEntity(request, entity);
+                result = Mapper.Map<TOut>(entity);
+            }
+
+            return new Response<TOut> { Data = result };
+        }
+    }
+}

--- a/Turner.Infrastructure.Crud/TaskExtensions.cs
+++ b/Turner.Infrastructure.Crud/TaskExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Turner.Infrastructure.Crud
+{
+    internal static class TaskExtensions
+    {
+        public static ConfiguredTaskAwaitable Configure(this Task task)
+        {
+            return task.ConfigureAwait(false);
+        }
+
+        public static ConfiguredTaskAwaitable<TResult> Configure<TResult>(this Task<TResult> task)
+        {
+            return task.ConfigureAwait(false);
+        }
+    }
+}

--- a/Turner.Infrastructure.Crud/Utilities/Selector.cs
+++ b/Turner.Infrastructure.Crud/Utilities/Selector.cs
@@ -35,7 +35,7 @@ namespace Turner.Infrastructure.Crud
             Func<TRequest, Expression<Func<TEntity, bool>>> selector)
             where TEntity : class
         {
-            _selector = request => selector((TRequest)request);
+            _selector = request => selector((TRequest) request);
 
             _boundRequestType = typeof(TRequest);
             _boundEntityType = typeof(TEntity);
@@ -70,7 +70,7 @@ namespace Turner.Infrastructure.Crud
                 return null;
 
             if (typeof(TEntity) == _boundEntityType)
-                return (Expression<Func<TEntity, bool>>)selectExpr;
+                return (Expression<Func<TEntity, bool>>) selectExpr;
 
             var entityParam = Expression.Parameter(typeof(TEntity));
             var tParam = Expression.Convert(entityParam, _boundEntityType);
@@ -79,7 +79,7 @@ namespace Turner.Infrastructure.Crud
             return Expression.Lambda<Func<TEntity, bool>>(invocation, entityParam);
         }
     }
-
+    
     public static class SelectorExtensions
     {
         public static TEntity Select<TRequest, TEntity>(

--- a/Turner.Infrastructure.Crud/Utilities/SelectorBuilder.cs
+++ b/Turner.Infrastructure.Crud/Utilities/SelectorBuilder.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Linq.Expressions;
+
+namespace Turner.Infrastructure.Crud.Utilities
+{
+    public class SelectorBuilder<TRequest, TEntity>
+        where TEntity : class
+    {
+        public Func<TRequest, Expression<Func<TEntity, bool>>> Build<TRequestKey, TEntityKey>(
+                Expression<Func<TRequest, TRequestKey>> requestKeyExpr,
+                Expression<Func<TEntity, TEntityKey>> entityKeyExpr)
+        {
+            return request =>
+            {
+                var eParamExpr = Expression.Parameter(typeof(TEntity));
+                var eKeyExpr = Expression.Invoke(entityKeyExpr, eParamExpr);
+                var rParamExpr = Expression.Constant(request);
+                var rKeyExpr = Expression.Invoke(requestKeyExpr, rParamExpr);
+                var compareExpr = Expression.Equal(eKeyExpr, rKeyExpr);
+
+                return Expression.Lambda<Func<TEntity, bool>>(compareExpr, eParamExpr);
+            };
+        }
+
+        public Func<TRequest, Expression<Func<TEntity, bool>>> Build(
+            string requestKeyProperty, string entityKeyProperty)
+        {
+            return request =>
+            {
+                var eParamExpr = Expression.Parameter(typeof(TEntity));
+                var eKeyExpr = Expression.Property(eParamExpr, entityKeyProperty);
+                var rParamExpr = Expression.Constant(request);
+                var rKeyExpr = Expression.Property(rParamExpr, requestKeyProperty);
+                var compareExpr = Expression.Equal(eKeyExpr, rKeyExpr);
+
+                return Expression.Lambda<Func<TEntity, bool>>(compareExpr, eParamExpr);
+            };
+        }
+    }
+}


### PR DESCRIPTION
- Update requests
- Request-wide pre- actions (run before entity pre- actions)
- Abstracted context calls out into injected "algorithm" objects
- Selector builder to make selector generation much easier
- GetByIdRequest (assumes an "Id" property on entity)
- GetByGuidRequest (assumes a "Guid" property on entity)