### PR TITLE
Feat/paged find requests

### DIFF
--- a/Turner.Infrastructure.Crud.Tests/RequestTests/GetAllRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/GetAllRequestTests.cs
@@ -545,7 +545,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
         public GetAllBasicUnconditionalFilteredUsersProfile()
         {
             ForEntity<IEntity>()
-                .FilterWith(builder => builder.On(x => !x.IsDeleted));
+                .FilterWith(builder => builder.FilterOn(x => !x.IsDeleted));
         }
     }
 
@@ -562,7 +562,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
         {
             ForEntity<IEntity>()
                 .FilterWith(builder => builder
-                    .On((request, entity) => entity.IsDeleted == request.DeletedFilter.Value)
+                    .FilterOn((request, entity) => entity.IsDeleted == request.DeletedFilter.Value)
                     .When(r => r.DeletedFilter.HasValue));
         }
     }

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/PagedFindRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/PagedFindRequestTests.cs
@@ -1,0 +1,71 @@
+﻿using NUnit.Framework;
+using System.Threading.Tasks;
+using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Requests;
+using Turner.Infrastructure.Crud.Tests.Fakes;
+using Turner.Infrastructure.Mediator.Decorators;
+
+namespace Turner.Infrastructure.Crud.Tests.RequestTests
+{
+    [TestFixture]
+    public class PagedFindRequestTests : BaseUnitTest
+    {
+        private async Task SeedEntities()
+        {
+            await Context.AddRangeAsync(
+                new User { Name = "CUser", IsDeleted = false },
+                new User { Name = "BUser", IsDeleted = true },
+                new User { Name = "FUser", IsDeleted = false },
+                new User { Name = "AUser", IsDeleted = false },
+                new User { Name = "EUser", IsDeleted = false },
+                new User { Name = "DUser", IsDeleted = false }
+            );
+
+            await Context.SaveChangesAsync();
+        }
+
+        [Test]
+        public async Task Handle_PagedFindRequest_ReturnsItemAndPageInfo()
+        {
+            await SeedEntities();
+
+            await Context.SaveChangesAsync();
+
+            var request = new PagedFindUser
+            {
+                Name = "CUser",
+                PageSize = 2
+            };
+
+            var response = await Mediator.HandleAsync(request);
+
+            Assert.IsFalse(response.HasErrors);
+            Assert.IsNotNull(response.Data);
+            Assert.IsNotNull(response.Data.Item);
+            Assert.AreEqual(5, response.Data.TotalItemCount);
+            Assert.AreEqual(2, response.Data.PageNumber);
+            Assert.AreEqual(2, response.Data.PageSize);
+            Assert.AreEqual(3, response.Data.PageCount);
+        }
+    }
+
+    [DoNotValidate]
+    public class PagedFindUser : IPagedFindRequest<User, UserGetDto>
+    {
+        public string Name { get; set; }
+
+        public int PageSize { get; set; }
+    }
+
+    public class PagedFindUserProfile : CrudRequestProfile<IPagedFindRequest>
+    {
+        public PagedFindUserProfile()
+        {
+            ForEntity<User>()
+                .SelectWith(builder => builder.Build("Name"))
+                .SortWith(builder => builder.SortBy("Name").Descending())
+                .FilterWith(builder => builder.FilterOn(x => !x.IsDeleted))
+                .ConfigureOptions(config => config.UseProjection = false);
+        }
+    }
+}

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/PagedGetAllRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/PagedGetAllRequestTests.cs
@@ -227,7 +227,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
 
             ForEntity<User>()
                 .FilterWith(builder => builder
-                    .On(request => entity => entity.IsDeleted == request.DeletedFilter.Value)
+                    .FilterOn(request => entity => entity.IsDeleted == request.DeletedFilter.Value)
                     .When(r => r.DeletedFilter.HasValue))
                 .SortWith(builder => builder.SortBy("Name"));
         }

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/PagedGetRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/PagedGetRequestTests.cs
@@ -1,0 +1,74 @@
+﻿using NUnit.Framework;
+using System.Threading.Tasks;
+using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Requests;
+using Turner.Infrastructure.Crud.Tests.Fakes;
+using Turner.Infrastructure.Mediator.Decorators;
+
+namespace Turner.Infrastructure.Crud.Tests.RequestTests
+{
+    [TestFixture]
+    public class PagedGetRequestTests : BaseUnitTest
+    {
+        private async Task SeedEntities()
+        {
+            await Context.AddRangeAsync(
+                new User { Name = "CUser", IsDeleted = false },
+                new User { Name = "BUser", IsDeleted = true },
+                new User { Name = "FUser", IsDeleted = false },
+                new User { Name = "AUser", IsDeleted = false },
+                new User { Name = "EUser", IsDeleted = false },
+                new User { Name = "DUser", IsDeleted = false }
+            );
+
+            await Context.SaveChangesAsync();
+        }
+
+        [Test]
+        public async Task Handle_PagedGetRequest_ReturnsItemPageAndPageInfo()
+        {
+            await SeedEntities();
+            
+            await Context.SaveChangesAsync();
+
+            var request = new PagedGetUser
+            {
+                Name = "CUser",
+                PageSize = 2
+            };
+
+            var response = await Mediator.HandleAsync(request);
+
+            Assert.IsFalse(response.HasErrors);
+            Assert.IsNotNull(response.Data);
+            Assert.IsNotNull(response.Data.Items);
+            Assert.AreEqual(2, response.Data.Items.Count);
+            Assert.AreEqual(5, response.Data.TotalItemCount);
+            Assert.AreEqual(2, response.Data.PageNumber);
+            Assert.AreEqual(2, response.Data.PageSize);
+            Assert.AreEqual(3, response.Data.PageCount);
+            Assert.AreEqual("DUser", response.Data.Items[0].Name);
+            Assert.AreEqual("CUser", response.Data.Items[1].Name);
+        }
+    }
+
+    [DoNotValidate]
+    public class PagedGetUser : IPagedGetRequest<User, UserGetDto>
+    {
+        public string Name { get; set; }
+
+        public int PageSize { get; set; }
+    }
+
+    public class PagedGetUserProfile : CrudRequestProfile<IPagedGetRequest>
+    {
+        public PagedGetUserProfile()
+        {
+            ForEntity<User>()
+                .SelectWith(builder => builder.Build("Name"))
+                .SortWith(builder => builder.SortBy("Name").Descending())
+                .FilterWith(builder => builder.FilterOn(x => !x.IsDeleted))
+                .ConfigureOptions(config => config.UseProjection = false);
+        }
+    }
+}

--- a/Turner.Infrastructure.Crud/Configuration/Builders/Filter/FilterBuilder.cs
+++ b/Turner.Infrastructure.Crud/Configuration/Builders/Filter/FilterBuilder.cs
@@ -15,7 +15,7 @@ namespace Turner.Infrastructure.Crud.Configuration.Builders.Filter
     {
         private FilterBuilderBase<TRequest, TEntity> _builder;
 
-        public BasicFilterBuilder<TRequest, TEntity> On(
+        public BasicFilterBuilder<TRequest, TEntity> FilterOn(
             Func<TRequest, Expression<Func<TEntity, bool>>> filterFunc)
         {
             var builder = new BasicFilterBuilder<TRequest, TEntity>(
@@ -26,10 +26,10 @@ namespace Turner.Infrastructure.Crud.Configuration.Builders.Filter
             return builder;
         }
 
-        public BasicFilterBuilder<TRequest, TEntity> On(
+        public BasicFilterBuilder<TRequest, TEntity> FilterOn(
             Expression<Func<TRequest, TEntity, bool>> filterExpr)
         {
-            return On(request =>
+            return FilterOn(request =>
             {
                 var requestParam = Expression.Constant(request, typeof(TRequest));
                 var body = filterExpr.Body.ReplaceParameter(filterExpr.Parameters[0], requestParam);
@@ -38,7 +38,7 @@ namespace Turner.Infrastructure.Crud.Configuration.Builders.Filter
             });
         }
 
-        public BasicFilterBuilder<TRequest, TEntity> On(
+        public BasicFilterBuilder<TRequest, TEntity> FilterOn(
             Expression<Func<TEntity, bool>> filterExpr)
         {
             var builder = new BasicFilterBuilder<TRequest, TEntity>(

--- a/Turner.Infrastructure.Crud/Configuration/CrudRequestErrorConfig.cs
+++ b/Turner.Infrastructure.Crud/Configuration/CrudRequestErrorConfig.cs
@@ -9,6 +9,8 @@ namespace Turner.Infrastructure.Crud.Configuration
 
         public bool? FailedToFindInGetAllIsError { get; set; }
 
+        public bool? FailedToFindInFindIsError { get; set; }
+
         public bool? FailedToFindInUpdateIsError { get; set; }
 
         public bool? FailedToFindInDeleteIsError { get; set; }

--- a/Turner.Infrastructure.Crud/Configuration/CrudRequestProfile.cs
+++ b/Turner.Infrastructure.Crud/Configuration/CrudRequestProfile.cs
@@ -173,6 +173,9 @@ namespace Turner.Infrastructure.Crud.Configuration
             if (errorConfig.FailedToFindInGetAllIsError.HasValue)
                 config.ErrorConfig.FailedToFindInGetAllIsError = errorConfig.FailedToFindInGetAllIsError.Value;
 
+            if (errorConfig.FailedToFindInFindIsError.HasValue)
+                config.ErrorConfig.FailedToFindInFindIsError = errorConfig.FailedToFindInFindIsError.Value;
+
             if (errorConfig.FailedToFindInUpdateIsError.HasValue)
                 config.ErrorConfig.FailedToFindInUpdateIsError = errorConfig.FailedToFindInUpdateIsError.Value;
 

--- a/Turner.Infrastructure.Crud/Configuration/ErrorConfig.cs
+++ b/Turner.Infrastructure.Crud/Configuration/ErrorConfig.cs
@@ -18,6 +18,8 @@ namespace Turner.Infrastructure.Crud.Configuration
 
         public bool FailedToFindInGetAllIsError { get; set; }
 
+        public bool FailedToFindInFindIsError { get; set; } = true;
+
         public bool FailedToFindInUpdateIsError { get; set; } = true;
 
         public bool FailedToFindInDeleteIsError { get; set; }

--- a/Turner.Infrastructure.Crud/Configuration/SimpleInjectorCrudConfiguration.cs
+++ b/Turner.Infrastructure.Crud/Configuration/SimpleInjectorCrudConfiguration.cs
@@ -54,6 +54,9 @@ namespace Turner.Infrastructure.Crud.Configuration
             container.Register(typeof(PagedGetAllRequestHandler<,,>), configAssemblies);
             container.RegisterConditional(typeof(IRequestHandler<,>), typeof(PagedGetAllRequestHandler<,,>), IfNotHandled);
 
+            container.Register(typeof(PagedFindRequestHandler<,,>), configAssemblies);
+            container.RegisterConditional(typeof(IRequestHandler<,>), typeof(PagedFindRequestHandler<,,>), IfNotHandled);
+
             container.Register(typeof(UpdateRequestHandler<,>), configAssemblies);
             container.Register(typeof(UpdateRequestHandler<,,>), configAssemblies);
             container.RegisterConditional(typeof(IRequestHandler<>), typeof(UpdateRequestHandler<,>), IfNotHandled);

--- a/Turner.Infrastructure.Crud/Configuration/SimpleInjectorCrudConfiguration.cs
+++ b/Turner.Infrastructure.Crud/Configuration/SimpleInjectorCrudConfiguration.cs
@@ -54,6 +54,9 @@ namespace Turner.Infrastructure.Crud.Configuration
             container.Register(typeof(PagedGetAllRequestHandler<,,>), configAssemblies);
             container.RegisterConditional(typeof(IRequestHandler<,>), typeof(PagedGetAllRequestHandler<,,>), IfNotHandled);
 
+            container.Register(typeof(PagedGetRequestHandler<,,>), configAssemblies);
+            container.RegisterConditional(typeof(IRequestHandler<,>), typeof(PagedGetRequestHandler<,,>), IfNotHandled);
+
             container.Register(typeof(PagedFindRequestHandler<,,>), configAssemblies);
             container.RegisterConditional(typeof(IRequestHandler<,>), typeof(PagedFindRequestHandler<,,>), IfNotHandled);
 

--- a/Turner.Infrastructure.Crud/Requests/IPagedRequest.cs
+++ b/Turner.Infrastructure.Crud/Requests/IPagedRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace Turner.Infrastructure.Crud.Requests
+{
+    public interface IPagedRequest : ICrudRequest
+    {
+        int PageNumber { get; set; }
+
+        int PageSize { get; set; }
+    }
+}

--- a/Turner.Infrastructure.Crud/Requests/PagedFindRequest.cs
+++ b/Turner.Infrastructure.Crud/Requests/PagedFindRequest.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Mediator;
+using Turner.Infrastructure.Mediator.Decorators;
+
+namespace Turner.Infrastructure.Crud.Requests
+{
+    #pragma warning disable 0618
+
+    [Obsolete("Linq does not currently support positional queries. PagedFindRequest may cause a large result set to be created.")]
+    public interface IPagedFindRequest : ICrudRequest
+    {
+        int PageSize { get; set; }
+    }
+
+    [Obsolete("Linq does not currently support positional queries. PagedFindRequest may cause a large result set to be created.")]
+    public interface IPagedFindRequest<TEntity, TOut> : IPagedFindRequest, IRequest<PagedFindResult<TOut>>
+        where TEntity : class
+    {
+    }
+    
+    public class PagedFindResult<TOut>
+    {
+        public TOut Item { get; set; }
+
+        public int PageNumber { get; set; }
+
+        public int PageSize { get; set; }
+
+        public int PageCount { get; set; }
+
+        public int TotalItemCount { get; set; }
+    }
+
+    [Obsolete("Linq does not currently support positional queries. PagedFindRequest may cause a large result set to be created.")]
+    [DoNotValidate]
+    public class PagedFindRequest<TEntity, TKey, TOut> : IPagedFindRequest<TEntity, TOut>
+        where TEntity : class
+    {
+        public PagedFindRequest(TKey key, int pageSize = 10)
+        {
+            Key = key;
+            PageSize = pageSize;
+        }
+        
+        public TKey Key { get; }
+
+        public int PageSize { get; set; }
+    }
+
+    [Obsolete("Linq does not currently support positional queries. PagedFindRequest may cause a large result set to be created.")]
+    [DoNotValidate]
+    public class PagedFindByIdRequest<TEntity, TOut> : PagedFindRequest<TEntity, int, TOut>
+        where TEntity : class
+    {
+        public PagedFindByIdRequest(int id, int pageSize = 10) 
+            : base(id, pageSize)
+        {
+        }
+    }
+
+    public class PagedFindByIdRequestProfile<TEntity, TOut>
+        : CrudRequestProfile<PagedFindByIdRequest<TEntity, TOut>>
+        where TEntity : class
+    {
+        public PagedFindByIdRequestProfile()
+        {
+            ForEntity<TEntity>()
+                .SelectWith(builder => builder.Build(request => request.Key, "Id"));
+        }
+    }
+
+    [Obsolete("Linq does not currently support positional queries. PagedFindRequest may cause a large result set to be created.")]
+    [DoNotValidate]
+    public class PagedFindByGuidRequest<TEntity, TOut> : PagedFindRequest<TEntity, Guid, TOut>
+        where TEntity : class
+    {
+        public PagedFindByGuidRequest(Guid guid, int pageSize = 10)
+            : base(guid, pageSize)
+        {
+        }
+    }
+
+    public class PagedFindByGuidRequestProfile<TEntity, TOut>
+        : CrudRequestProfile<PagedFindByGuidRequest<TEntity, TOut>>
+        where TEntity : class
+    {
+        public PagedFindByGuidRequestProfile()
+        {
+            ForEntity<TEntity>()
+                .SelectWith(builder => builder.Build(request => request.Key, "Guid"));
+        }
+    }
+
+    #pragma warning restore 0618
+}

--- a/Turner.Infrastructure.Crud/Requests/PagedFindRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/PagedFindRequestHandler.cs
@@ -1,0 +1,99 @@
+﻿using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading.Tasks;
+using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Errors;
+using Turner.Infrastructure.Crud.Exceptions;
+using Turner.Infrastructure.Mediator;
+
+namespace Turner.Infrastructure.Crud.Requests
+{
+    #pragma warning disable 0618
+
+    internal class PagedFindRequestHandler<TRequest, TEntity, TOut>
+        : CrudRequestHandler<TRequest, TEntity>, IRequestHandler<TRequest, PagedFindResult<TOut>>
+        where TEntity : class
+        where TRequest : IPagedFindRequest<TEntity, TOut>
+    {
+        protected readonly IGetAllAlgorithm Algorithm;
+        protected readonly RequestOptions Options;
+
+        public PagedFindRequestHandler(DbContext context,
+            CrudConfigManager profileManager,
+            IGetAllAlgorithm algorithm)
+            : base(context, profileManager)
+        {
+            Algorithm = algorithm;
+            Options = RequestConfig.GetOptionsFor<TEntity>();
+        }
+
+        public async Task<Response<PagedFindResult<TOut>>> HandleAsync(TRequest request)
+        {
+            PagedFindResult<TOut> result;
+            var failedToFind = false;
+
+            try
+            {
+                var selector = RequestConfig.GetSelectorFor<TEntity>();
+                var entities = Algorithm
+                    .GetEntities<TEntity>(Context)
+                    .AsQueryable();
+
+                foreach (var filter in RequestConfig.GetFiltersFor<TEntity>())
+                    entities = filter.Filter(request, entities);
+
+                var sorter = RequestConfig.GetSorterFor<TEntity>();
+                entities = sorter?.Sort(request, entities) ?? entities;
+
+                var totalItemCount = await entities.CountAsync();
+                var pageSize = request.PageSize < 1 ? totalItemCount : request.PageSize;
+                var totalPageCount = totalItemCount == 0 ? 1 : (totalItemCount + pageSize - 1) / pageSize;
+                
+                var item = (await entities.ToArrayAsync())
+                    .Select((e, i) => new { Item = e, Index = i })
+                    .SingleOrDefault(x => selector.Get<TEntity>()(request).Compile()(x.Item));
+                
+                if (item != null)
+                {
+                    result = new PagedFindResult<TOut>
+                    {
+                        Item = Mapper.Map<TOut>(item.Item),
+                        PageNumber = 1 + (item.Index / pageSize),
+                        PageSize = pageSize,
+                        PageCount = totalPageCount,
+                        TotalItemCount = totalItemCount
+                    };
+                }
+                else
+                { 
+                    failedToFind = true;
+
+                    result = new PagedFindResult<TOut>
+                    {
+                        Item = Mapper.Map<TOut>(RequestConfig.GetDefaultFor<TEntity>()),
+                        PageNumber = 0,
+                        PageSize = pageSize,
+                        PageCount = totalPageCount,
+                        TotalItemCount = totalItemCount
+                    };
+                }
+            }
+            catch (CrudRequestFailedException e)
+            {
+                var error = new RequestFailedError(request, e);
+                return ErrorDispatcher.Dispatch<PagedFindResult<TOut>>(error);
+            }
+
+            if (failedToFind && RequestConfig.ErrorConfig.FailedToFindInFindIsError)
+            {
+                var error = new FailedToFindError(request, typeof(TEntity), result);
+                return ErrorDispatcher.Dispatch<PagedFindResult<TOut>>(error);
+            }
+
+            return result.AsResponse();
+        }
+    }
+
+    #pragma warning restore 0618
+}

--- a/Turner.Infrastructure.Crud/Requests/PagedGetAllRequest.cs
+++ b/Turner.Infrastructure.Crud/Requests/PagedGetAllRequest.cs
@@ -5,11 +5,8 @@ using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    public interface IPagedGetAllRequest : IGetAllRequest
+    public interface IPagedGetAllRequest : IPagedRequest, IGetAllRequest
     {
-        int PageNumber { get; set; }
-
-        int PageSize { get; set; }
     }
 
     public interface IPagedGetAllRequest<TEntity, TOut> : IPagedGetAllRequest, IRequest<PagedGetAllResult<TOut>>

--- a/Turner.Infrastructure.Crud/Requests/PagedGetRequest.cs
+++ b/Turner.Infrastructure.Crud/Requests/PagedGetRequest.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Mediator;
+using Turner.Infrastructure.Mediator.Decorators;
+
+namespace Turner.Infrastructure.Crud.Requests
+{
+#pragma warning disable 0618
+
+    [Obsolete("Linq does not currently support positional queries. PagedGetRequest may cause a large result set to be created.")]
+    public interface IPagedGetRequest : ICrudRequest
+    {
+        int PageSize { get; set; }
+    }
+
+    [Obsolete("Linq does not currently support positional queries. PagedGetRequest may cause a large result set to be created.")]
+    public interface IPagedGetRequest<TEntity, TOut> : IPagedGetRequest, IRequest<PagedGetResult<TOut>>
+        where TEntity : class
+    {
+    }
+
+    public class PagedGetResult<TOut>
+    {
+        public List<TOut> Items { get; set; }
+
+        public int PageNumber { get; set; }
+
+        public int PageSize { get; set; }
+
+        public int PageCount { get; set; }
+
+        public int TotalItemCount { get; set; }
+    }
+
+    [Obsolete("Linq does not currently support positional queries. PagedGetRequest may cause a large result set to be created.")]
+    [DoNotValidate]
+    public class PagedGetRequest<TEntity, TKey, TOut> : IPagedGetRequest<TEntity, TOut>
+        where TEntity : class
+    {
+        public PagedGetRequest(TKey key, int pageSize = 10)
+        {
+            Key = key;
+            PageSize = pageSize;
+        }
+
+        public TKey Key { get; }
+
+        public int PageSize { get; set; }
+    }
+
+    [Obsolete("Linq does not currently support positional queries. PagedGetRequest may cause a large result set to be created.")]
+    [DoNotValidate]
+    public class PagedGetByIdRequest<TEntity, TOut> : PagedGetRequest<TEntity, int, TOut>
+        where TEntity : class
+    {
+        public PagedGetByIdRequest(int id, int pageSize = 10)
+            : base(id, pageSize)
+        {
+        }
+    }
+
+    public class PagedGetByIdRequestProfile<TEntity, TOut>
+        : CrudRequestProfile<PagedGetByIdRequest<TEntity, TOut>>
+        where TEntity : class
+    {
+        public PagedGetByIdRequestProfile()
+        {
+            ForEntity<TEntity>()
+                .SelectWith(builder => builder.Build(request => request.Key, "Id"));
+        }
+    }
+
+    [Obsolete("Linq does not currently support positional queries. PagedGetRequest may cause a large result set to be created.")]
+    [DoNotValidate]
+    public class PagedGetByGuidRequest<TEntity, TOut> : PagedGetRequest<TEntity, Guid, TOut>
+        where TEntity : class
+    {
+        public PagedGetByGuidRequest(Guid guid, int pageSize = 10)
+            : base(guid, pageSize)
+        {
+        }
+    }
+
+    public class PagedGetByGuidRequestProfile<TEntity, TOut>
+        : CrudRequestProfile<PagedGetByGuidRequest<TEntity, TOut>>
+        where TEntity : class
+    {
+        public PagedGetByGuidRequestProfile()
+        {
+            ForEntity<TEntity>()
+                .SelectWith(builder => builder.Build(request => request.Key, "Guid"));
+        }
+    }
+
+#pragma warning restore 0618
+}

--- a/Turner.Infrastructure.Crud/Requests/PagedGetRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/PagedGetRequestHandler.cs
@@ -1,0 +1,105 @@
+﻿using AutoMapper;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Errors;
+using Turner.Infrastructure.Crud.Exceptions;
+using Turner.Infrastructure.Mediator;
+
+namespace Turner.Infrastructure.Crud.Requests
+{
+#pragma warning disable 0618
+
+    internal class PagedGetRequestHandler<TRequest, TEntity, TOut>
+        : CrudRequestHandler<TRequest, TEntity>, IRequestHandler<TRequest, PagedGetResult<TOut>>
+        where TEntity : class
+        where TRequest : IPagedGetRequest<TEntity, TOut>
+    {
+        protected readonly IGetAllAlgorithm Algorithm;
+        protected readonly RequestOptions Options;
+
+        public PagedGetRequestHandler(DbContext context,
+            CrudConfigManager profileManager,
+            IGetAllAlgorithm algorithm)
+            : base(context, profileManager)
+        {
+            Algorithm = algorithm;
+            Options = RequestConfig.GetOptionsFor<TEntity>();
+        }
+
+        public async Task<Response<PagedGetResult<TOut>>> HandleAsync(TRequest request)
+        {
+            PagedGetResult<TOut> result;
+            var failedToFind = false;
+
+            try
+            {
+                var selector = RequestConfig.GetSelectorFor<TEntity>();
+                var entities = Algorithm
+                    .GetEntities<TEntity>(Context)
+                    .AsQueryable();
+
+                foreach (var filter in RequestConfig.GetFiltersFor<TEntity>())
+                    entities = filter.Filter(request, entities);
+
+                var sorter = RequestConfig.GetSorterFor<TEntity>();
+                entities = sorter?.Sort(request, entities) ?? entities;
+
+                var totalItemCount = await entities.CountAsync();
+                var pageSize = request.PageSize < 1 ? totalItemCount : request.PageSize;
+                var totalPageCount = totalItemCount == 0 ? 1 : (totalItemCount + pageSize - 1) / pageSize;
+
+                var allItems = await entities.ToArrayAsync();
+                var item = allItems
+                    .Select((e, i) => new { Item = e, Index = i })
+                    .SingleOrDefault(x => selector.Get<TEntity>()(request).Compile()(x.Item));
+
+                var resultItems = new List<TOut>();
+                var pageNumber = 0;
+
+                if (item != null)
+                {
+                    var pageItems = allItems.Skip(item.Index / pageSize * pageSize).Take(pageSize);
+                    resultItems = Mapper.Map<List<TOut>>(pageItems);
+                    pageNumber = 1 + (item.Index / pageSize);
+                }
+                else
+                {
+                    failedToFind = true;
+
+                    var defaultValue = RequestConfig.GetDefaultFor<TEntity>();
+                    if (defaultValue != null)
+                        resultItems.Add(Mapper.Map<TOut>(defaultValue));
+
+                    pageNumber = 0;
+                }
+
+                result = new PagedGetResult<TOut>
+                {
+                    Items = resultItems,
+                    PageNumber = pageNumber,
+                    PageSize = pageSize,
+                    PageCount = totalPageCount,
+                    TotalItemCount = totalItemCount
+                };
+            }
+            catch (CrudRequestFailedException e)
+            {
+                var error = new RequestFailedError(request, e);
+                return ErrorDispatcher.Dispatch<PagedGetResult<TOut>>(error);
+            }
+
+            if (failedToFind && RequestConfig.ErrorConfig.FailedToFindInFindIsError)
+            {
+                var error = new FailedToFindError(request, typeof(TEntity), result);
+                return ErrorDispatcher.Dispatch<PagedGetResult<TOut>>(error);
+            }
+
+            return result.AsResponse();
+        }
+    }
+
+    #pragma warning restore 0618
+}


### PR DESCRIPTION
- Added implementations of `PagedFindRequest` and `PagedGetRequest` to search for and return an item with paging information or the item's entire page
- Unfortunately, these requests **should probably not be used** until EF supports positional queries, because they are currently forced to pull down _all_ entities in a table (after filtering)