### PR TITLE
Feat/validation

### DIFF
--- a/Turner.Infrastructure.Crud.Tests/AlgorithmTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/AlgorithmTests.cs
@@ -46,7 +46,8 @@ namespace Turner.Infrastructure.Crud.Tests
             UnitTestSetUp.ConfigureDatabase(container);
 
             container.ConfigureMediator(assemblies);
-            container.ConfigureCrud(assemblies);
+
+            Crud.Configure(container, assemblies);
 
             container.Options.AllowOverridingRegistrations = true;
             container.Register<IEntityContext, InMemoryContext>();

--- a/Turner.Infrastructure.Crud.Tests/ErrorHandlerTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/ErrorHandlerTests.cs
@@ -42,7 +42,8 @@ namespace Turner.Infrastructure.Crud.Tests
             UnitTestSetUp.ConfigureDatabase(container);
             
             container.ConfigureMediator(assemblies);
-            container.ConfigureCrud(assemblies);
+
+            Crud.Configure(container, assemblies);
             
             container.Options.AllowOverridingRegistrations = true;
             container.Register<ICrudErrorHandler, TestErrorHandler>(Lifestyle.Singleton);

--- a/Turner.Infrastructure.Crud.Tests/HookTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/HookTests.cs
@@ -1,5 +1,4 @@
-﻿using AutoMapper;
-using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.EntityFrameworkCore;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/CreateAllRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/CreateAllRequestTests.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Tests.RequestTests
 {
@@ -104,14 +103,12 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
     {
         UserDto[] Users { get; set; }
     }
-
-    [DoNotValidate]
+    
     public class CreateUsersWithResponseRequest : ICreateAllCommon, ICreateAllRequest<User, UserGetDto>
     {
         public UserDto[] Users { get; set; }
     }
-
-    [DoNotValidate]
+    
     public class CreateUsersWithoutResponseRequest : ICreateAllCommon, ICreateAllRequest<User>
     {
         public UserDto[] Users { get; set; }

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/CreateRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/CreateRequestTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Tests.RequestTests
 {
@@ -97,18 +96,15 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
             Assert.AreEqual(response.Data.Id, Context.Set<User>().First().Id);
         }
     }
-
-    [DoNotValidate]
+    
     public class CreateUserWithResponseRequest : UserDto, ICreateRequest<User, UserGetDto>
     { }
-
-    [DoNotValidate]
+    
     public class CreateUserWithoutResponseRequest : ICreateRequest<User>
     {
         public UserDto User { get; set; }
     }
-
-    [DoNotValidate]
+    
     public class DerivedCreateUserWithoutResponseRequest : CreateUserWithoutResponseRequest
     {
         public object OtherStuff { get; set; }

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/DeleteAllRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/DeleteAllRequestTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Tests.RequestTests
 {
@@ -77,8 +76,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
             Assert.IsFalse(Context.Set<User>().First(x => x.Name == "TestUser4").IsDeleted);
         }
     }
-
-    [DoNotValidate]
+    
     public class DeleteAllUsersByIdRequest
         : IDeleteAllRequest<User, UserGetDto>
     {

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/DeleteRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/DeleteRequestTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Tests.RequestTests
 {
@@ -103,14 +102,12 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
         }
     }
     
-    [DoNotValidate]
     public class DeleteUserByIdRequest 
         : IDeleteRequest<User, UserGetDto>
     {
         public int Id { get; set; }
     }
-
-    [DoNotValidate]
+    
     public class DeleteUserByNameRequest
         : IDeleteRequest<User>
     {

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/GetAllRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/GetAllRequestTests.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Tests.RequestTests
 {
@@ -428,8 +427,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
         public const string Name = "Name";
         public const string IsDeleted = "IsDeleted";
     };
-
-    [DoNotValidate]
+    
     public class GetAllSimpleSortedUsers : IGetAllRequest<User, UserGetDto>
     {
     }
@@ -442,8 +440,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
             ForEntity<User>().SortWith(builder => builder.SortBy(x => x.Name).Descending());
         }
     }
-
-    [DoNotValidate]
+    
     public class GetAllCustomSortedUsers : IGetAllRequest<User, UserGetDto>
     {
     }
@@ -458,7 +455,6 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
         }
     }
     
-    [DoNotValidate]
     public class GetAllBasicSortedUsers : IGetAllRequest<User, UserGetDto>
     {
         public bool GroupDeleted { get; set; }
@@ -478,8 +474,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
                         .Otherwise());
         }
     }
-
-    [DoNotValidate]
+    
     public class GetAllSwitchSortedUsers : IGetAllRequest<User, UserGetDto>
     {
         public string Case { get; set; }
@@ -497,8 +492,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
                     .ForDefault().SortBy(user => user.IsDeleted).ThenBy("Name").Descending());
         }
     }
-
-    [DoNotValidate]
+    
     public class GetAllTableSortedUsers : IGetAllRequest<User, UserGetDto>
     {
         public string PrimaryColumn { get; set; }
@@ -521,8 +515,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
                     .WithColumn(UsersSortColumn.IsDeleted, user => user.IsDeleted));
         }
     }
-
-    [DoNotValidate]
+    
     public class GetAllCustomFilteredUsers
         : IGetAllRequest<User, UserGetDto>
     { }
@@ -540,8 +533,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
                 .FilterWith(builder => builder.FilterWith((request, users) => users.Where(x => x.Name != "AUser")));
         }
     }
-
-    [DoNotValidate]
+    
     public class GetAllBasicUnconditionalFilteredUsers
         : IGetAllRequest<User, UserGetDto>
     { }
@@ -555,8 +547,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
                 .FilterWith(builder => builder.FilterOn(x => !x.IsDeleted));
         }
     }
-
-    [DoNotValidate]
+    
     public class GetAllBasicConditionalFilteredUsers
         : IGetAllRequest<User, UserGetDto>
     {
@@ -574,23 +565,19 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
                     .When(r => r.DeletedFilter.HasValue));
         }
     }
-
-    [DoNotValidate]
+    
     public class GetUsersWithDefaultWithErrorRequest 
         : IGetAllRequest<User, UserGetDto>
     { }
-
-    [DoNotValidate]
+    
     public class GetUsersWithDefaultWithoutErrorRequest 
         : IGetAllRequest<User, UserGetDto>
     { }
-
-    [DoNotValidate]
+    
     public class GetUsersWithoutDefaultWithErrorRequest 
         : IGetAllRequest<User, UserGetDto>
     { }
-
-    [DoNotValidate]
+    
     public class GetUsersWithoutDefaultWithoutErrorRequest 
         : IGetAllRequest<User, UserGetDto>
     { }
@@ -632,8 +619,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
             ConfigureErrors(config => config.FailedToFindInGetAllIsError = false);
         }
     }
-
-    [DoNotValidate]
+    
     public class GetUsersUnprojectedRequest : GetAllRequest<User, UserGetDto> { }
 
     public class GetUsersUnprojectedProfile : CrudRequestProfileCommon<GetUsersUnprojectedRequest>

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/GetRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/GetRequestTests.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Tests.RequestTests
 {
@@ -118,20 +117,17 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
             Assert.AreEqual(_user.Name, response.Data.Name);
         }
     }
-
-    [DoNotValidate]
+    
     public class GetUserByIdRequest : IGetRequest<User, UserGetDto>
     {
         public int Id { get; set; }
     }
     
-    [DoNotValidate]
     public class GetUserByNameRequest : IGetRequest<User, UserGetDto>
     {
         public string Name { get; set; }
     }
-
-    [DoNotValidate]
+    
     public class GetUserByKeyRequest : IGetRequest<User, UserGetDto>
     {
         public int Id { get; set; }

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/MergeRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/MergeRequestTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Tests.RequestTests
 {
@@ -96,8 +95,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
             Assert.AreEqual(7, Context.Set<User>().Count());
         }
     }
-
-    [DoNotValidate]
+    
     public class MergeUsersByIdRequest
         : IMergeRequest<User, UserGetDto>
     {

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/PagedFindRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/PagedFindRequestTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Tests.RequestTests
 {
@@ -48,8 +47,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
             Assert.AreEqual(3, response.Data.PageCount);
         }
     }
-
-    [DoNotValidate]
+    
     public class PagedFindUser : IPagedFindRequest<User, UserGetDto>
     {
         public string Name { get; set; }

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/PagedGetAllRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/PagedGetAllRequestTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Tests.RequestTests
 {
@@ -191,8 +190,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
             Assert.AreEqual("DUser", response.Data.Items[1].Name);
         }
     }
-
-    [DoNotValidate]
+    
     public class GetAllUsersPaged : IPagedGetAllRequest<User, UserGetDto>
     {
         public int PageNumber { get; set; }
@@ -208,8 +206,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
             ForEntity<User>().SortWith(builder => builder.SortBy(x => x.Name).Descending());
         }
     }
-
-    [DoNotValidate]
+    
     public class GetAllFilteredUsersPaged
         : IPagedGetAllRequest<User, UserGetDto>
     {

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/PagedGetRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/PagedGetRequestTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Tests.RequestTests
 {
@@ -73,8 +72,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
             Assert.AreEqual("AUser", response.Data.Items[1].Name);
         }
     }
-
-    [DoNotValidate]
+    
     public class PagedGetUserRequest : IPagedGetRequest<User, UserGetDto>
     {
         public string Name { get; set; }

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/SaveRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/SaveRequestTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Tests.RequestTests
 {
@@ -145,12 +144,10 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
             Assert.AreEqual("NewUser", Context.Set<User>().First().Name);
         }
     }
-
-    [DoNotValidate]
+    
     public class SaveUserWithResponseRequest : UserDto, ISaveRequest<User, UserGetDto>
     { }
-
-    [DoNotValidate]
+    
     public class SaveUserWithoutResponseRequest : ISaveRequest<User>
     {
         public int Id { get; set; }

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/SynchronizeRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/SynchronizeRequestTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Tests.RequestTests
 {
@@ -98,8 +97,7 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
             Assert.AreEqual(5, Context.Set<User>().Count(x => !x.IsDeleted));
         }
     }
-
-    [DoNotValidate]
+    
     public class SynchronizeUsersByIdRequest
         : ISynchronizeRequest<User, UserGetDto>
     {

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/UpdateAllRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/UpdateAllRequestTests.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Tests.RequestTests
 {
@@ -83,7 +82,6 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
         }
     }
     
-    [DoNotValidate]
     public class UpdateAllUsersByIdRequest
         : IUpdateAllRequest<User, UserGetDto>
     {

--- a/Turner.Infrastructure.Crud.Tests/RequestTests/UpdateRequestTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/RequestTests/UpdateRequestTests.cs
@@ -1,5 +1,4 @@
 ﻿using AutoMapper;
-using Microsoft.EntityFrameworkCore;
 using NUnit.Framework;
 using System;
 using System.Linq;
@@ -7,7 +6,6 @@ using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Tests.RequestTests
 {
@@ -145,14 +143,12 @@ namespace Turner.Infrastructure.Crud.Tests.RequestTests
         }
     }
     
-    [DoNotValidate]
     public class UpdateUserByIdRequest 
         : UserDto, IUpdateRequest<User, UserGetDto>
     {
         public int Id { get; set; }
     }
-
-    [DoNotValidate]
+    
     public class UpdateUserByNameRequest
         : IUpdateRequest<User>
     {

--- a/Turner.Infrastructure.Crud.Tests/UnitTestSetup.cs
+++ b/Turner.Infrastructure.Crud.Tests/UnitTestSetup.cs
@@ -7,9 +7,7 @@ using SimpleInjector;
 using SimpleInjector.Lifestyles;
 using System;
 using System.Reflection;
-using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Tests.Fakes;
-using Turner.Infrastructure.Crud.Validation;
 using Turner.Infrastructure.Mediator.Configuration;
 
 namespace Turner.Infrastructure.Crud.Tests
@@ -36,7 +34,8 @@ namespace Turner.Infrastructure.Crud.Tests
             var crudOptions = new CrudOptions
             {
                 UseFluentValidation = true,
-                UseEntityFramework = true
+                UseEntityFramework = true,
+                ValidateAllRequests = false
             };
 
             Crud.Configure(container, assemblies, crudOptions);
@@ -69,7 +68,7 @@ namespace Turner.Infrastructure.Crud.Tests
 
         public static void ConfigureFluentValidation(Container container, Assembly[] assemblies)
         {
-            container.Register(typeof(FluentValidation.IValidator<>), assemblies);
+            container.Register(typeof(IValidator<>), assemblies);
 
             ValidatorOptions.CascadeMode = CascadeMode.StopOnFirstFailure;
         }

--- a/Turner.Infrastructure.Crud.Tests/UnitTestSetup.cs
+++ b/Turner.Infrastructure.Crud.Tests/UnitTestSetup.cs
@@ -1,4 +1,5 @@
 ﻿using AutoMapper;
+using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using NUnit.Framework;
@@ -8,6 +9,7 @@ using System;
 using System.Reflection;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Tests.Fakes;
+using Turner.Infrastructure.Crud.Validation;
 using Turner.Infrastructure.Mediator.Configuration;
 
 namespace Turner.Infrastructure.Crud.Tests
@@ -27,6 +29,7 @@ namespace Turner.Infrastructure.Crud.Tests
 
             ConfigureDatabase(container);
             ConfigureAutoMapper(container, assemblies);
+            ConfigureFluentValidation(container, assemblies);
 
             container.ConfigureMediator(assemblies);
             container.ConfigureCrud(assemblies);
@@ -55,6 +58,17 @@ namespace Turner.Infrastructure.Crud.Tests
             {
                 config.AddProfiles(assemblies);
             });
+        }
+
+        public static void ConfigureFluentValidation(Container container, Assembly[] assemblies)
+        {
+            // TODO: Crud global options - UseFluentValidation ?
+            // Also, UseAutoMapper ?
+            container.Register(typeof(Validation.IValidator<>), typeof(FluentValidator<>));
+
+            container.Register(typeof(FluentValidation.IValidator<>), assemblies);
+
+            ValidatorOptions.CascadeMode = CascadeMode.StopOnFirstFailure;
         }
     }
 }

--- a/Turner.Infrastructure.Crud.Tests/UnitTestSetup.cs
+++ b/Turner.Infrastructure.Crud.Tests/UnitTestSetup.cs
@@ -32,7 +32,13 @@ namespace Turner.Infrastructure.Crud.Tests
             ConfigureFluentValidation(container, assemblies);
 
             container.ConfigureMediator(assemblies);
-            container.ConfigureCrud(assemblies);
+
+            var crudOptions = new CrudOptions
+            {
+                UseFluentValidation = true
+            };
+
+            Crud.Configure(container, assemblies, crudOptions);
             
             Container = container;
         }
@@ -62,10 +68,6 @@ namespace Turner.Infrastructure.Crud.Tests
 
         public static void ConfigureFluentValidation(Container container, Assembly[] assemblies)
         {
-            // TODO: Crud global options - UseFluentValidation ?
-            // Also, UseAutoMapper ?
-            container.Register(typeof(Validation.IValidator<>), typeof(FluentValidator<>));
-
             container.Register(typeof(FluentValidation.IValidator<>), assemblies);
 
             ValidatorOptions.CascadeMode = CascadeMode.StopOnFirstFailure;

--- a/Turner.Infrastructure.Crud.Tests/UnitTestSetup.cs
+++ b/Turner.Infrastructure.Crud.Tests/UnitTestSetup.cs
@@ -35,7 +35,8 @@ namespace Turner.Infrastructure.Crud.Tests
 
             var crudOptions = new CrudOptions
             {
-                UseFluentValidation = true
+                UseFluentValidation = true,
+                UseEntityFramework = true
             };
 
             Crud.Configure(container, assemblies, crudOptions);

--- a/Turner.Infrastructure.Crud/Algorithms/EFEntitySet.cs
+++ b/Turner.Infrastructure.Crud/Algorithms/EFEntitySet.cs
@@ -28,10 +28,10 @@ namespace Turner.Infrastructure.Crud.Algorithms
 
         internal static EFEntitySet<TEntity> From(DbSet<TEntity> set)
         {
-            var entitySet = new EFEntitySet<TEntity>();
-            entitySet._set = set;
-
-            return entitySet;
+            return new EFEntitySet<TEntity>
+            {
+                _set = set
+            };
         }
         
         public virtual TEntity Create(TEntity entity) => _set.Add(entity).Entity;

--- a/Turner.Infrastructure.Crud/Configuration/Builders/Entity/CrudBulkRequestEntityConfigBuilder.cs
+++ b/Turner.Infrastructure.Crud/Configuration/Builders/Entity/CrudBulkRequestEntityConfigBuilder.cs
@@ -23,7 +23,7 @@ namespace Turner.Infrastructure.Crud.Configuration.Builders
             Expression<Func<TRequest, IEnumerable<TItem>>> requestItemsExpr)
         {
             _getRequestItems = requestItemsExpr;
-            RequestItemSource = Crud.RequestItemSource.From(BuildItemSource(requestItemsExpr));
+            RequestItemSource = Infrastructure.Crud.RequestItemSource.From(BuildItemSource(requestItemsExpr));
 
             return this;
         }

--- a/Turner.Infrastructure.Crud/Configuration/Builders/Entity/CrudRequestEntityConfigBuilderCommon.cs
+++ b/Turner.Infrastructure.Crud/Configuration/Builders/Entity/CrudRequestEntityConfigBuilderCommon.cs
@@ -22,7 +22,7 @@ namespace Turner.Infrastructure.Crud.Configuration.Builders
         protected readonly List<IEntityHookFactory> EntityHooks
             = new List<IEntityHookFactory>();
 
-        protected CrudOptionsConfig OptionsConfig;
+        protected CrudRequestOptionsConfig OptionsConfig;
         protected TEntity DefaultValue;
         protected ISorter Sorter;
         protected ISelector Selector;
@@ -33,7 +33,7 @@ namespace Turner.Infrastructure.Crud.Configuration.Builders
         protected Func<object, TEntity, Task<TEntity>> UpdateEntity;
         protected Func<ICrudErrorHandler> ErrorHandlerFactory;
         
-        public TBuilder ConfigureOptions(Action<CrudOptionsConfig> config)
+        public TBuilder ConfigureOptions(Action<CrudRequestOptionsConfig> config)
         {
             if (config == null)
             {
@@ -41,7 +41,7 @@ namespace Turner.Infrastructure.Crud.Configuration.Builders
             }
             else
             {
-                OptionsConfig = new CrudOptionsConfig();
+                OptionsConfig = new CrudRequestOptionsConfig();
                 config(OptionsConfig);
             }
 

--- a/Turner.Infrastructure.Crud/Configuration/CrudRequestConfig.cs
+++ b/Turner.Infrastructure.Crud/Configuration/CrudRequestConfig.cs
@@ -66,8 +66,8 @@ namespace Turner.Infrastructure.Crud.Configuration
 
         private readonly RequestOptions _options = new RequestOptions();
 
-        private readonly Dictionary<Type, CrudOptionsConfig> _entityOptionOverrides
-            = new Dictionary<Type, CrudOptionsConfig>();
+        private readonly Dictionary<Type, CrudRequestOptionsConfig> _entityOptionOverrides
+            = new Dictionary<Type, CrudRequestOptionsConfig>();
 
         private readonly Dictionary<Type, RequestOptions> _optionsCache
             = new Dictionary<Type, RequestOptions>();
@@ -289,13 +289,13 @@ namespace Turner.Infrastructure.Crud.Configuration
             return null;
         }
 
-        internal void SetOptions(CrudOptionsConfig options)
+        internal void SetOptions(CrudRequestOptionsConfig options)
         {
             if (options != null)
                 OverrideOptions(_options, options);
         }
 
-        internal void SetOptionsFor<TEntity>(CrudOptionsConfig options)
+        internal void SetOptionsFor<TEntity>(CrudRequestOptionsConfig options)
         {
             _entityOptionOverrides[typeof(TEntity)] = options;
         }
@@ -401,7 +401,7 @@ namespace Turner.Infrastructure.Crud.Configuration
             }
         }
 
-        private void OverrideOptions(RequestOptions options, CrudOptionsConfig config)
+        private void OverrideOptions(RequestOptions options, CrudRequestOptionsConfig config)
         {
             if (config.UseProjection.HasValue)
                 options.UseProjection = config.UseProjection.Value;

--- a/Turner.Infrastructure.Crud/Configuration/CrudRequestOptionsConfig.cs
+++ b/Turner.Infrastructure.Crud/Configuration/CrudRequestOptionsConfig.cs
@@ -1,6 +1,6 @@
 ﻿namespace Turner.Infrastructure.Crud.Configuration
 {
-    public class CrudOptionsConfig
+    public class CrudRequestOptionsConfig
     {
         public bool? SuppressCreateActionsInSave { get; set; }
 

--- a/Turner.Infrastructure.Crud/Configuration/CrudRequestProfile.cs
+++ b/Turner.Infrastructure.Crud/Configuration/CrudRequestProfile.cs
@@ -28,7 +28,7 @@ namespace Turner.Infrastructure.Crud.Configuration
         private readonly List<CrudRequestProfile> _inheritProfiles 
             = new List<CrudRequestProfile>();
 
-        private Action<CrudOptionsConfig> _optionsConfig;
+        private Action<CrudRequestOptionsConfig> _optionsConfig;
         private Action<CrudRequestErrorConfig> _errorConfig;
  
         protected readonly List<IRequestHookFactory> RequestHooks
@@ -68,7 +68,7 @@ namespace Turner.Infrastructure.Crud.Configuration
 
             if (_optionsConfig != null)
             {
-                var options = new CrudOptionsConfig();
+                var options = new CrudRequestOptionsConfig();
                 _optionsConfig(options);
                 config.SetOptions(options);
             }
@@ -102,7 +102,7 @@ namespace Turner.Infrastructure.Crud.Configuration
             RequestHooks.Add(FunctionRequestHookFactory.From(hook));
         }
 
-        protected void ConfigureOptions(Action<CrudOptionsConfig> config)
+        protected void ConfigureOptions(Action<CrudRequestOptionsConfig> config)
         {
             _optionsConfig = config;
         }

--- a/Turner.Infrastructure.Crud/Configuration/SimpleInjectorCrudConfiguration.cs
+++ b/Turner.Infrastructure.Crud/Configuration/SimpleInjectorCrudConfiguration.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using Turner.Infrastructure.Crud.Algorithms;
 using Turner.Infrastructure.Crud.Errors;
 using Turner.Infrastructure.Crud.Requests;
+using Turner.Infrastructure.Crud.Validation;
 using Turner.Infrastructure.Mediator;
 
 namespace Turner.Infrastructure.Crud.Configuration
@@ -13,6 +14,8 @@ namespace Turner.Infrastructure.Crud.Configuration
     {
         public static void ConfigureCrud(this Container container, Assembly[] assemblies)
         {
+            // TODO: This function has gotten too long; split it up
+
             var allAssemblies = new Assembly[1 + assemblies.Length];
             allAssemblies[0] = typeof(SimpleInjectorCrudConfiguration).Assembly;
             Array.Copy(assemblies, 0, allAssemblies, 1, assemblies.Length);
@@ -27,6 +30,56 @@ namespace Turner.Infrastructure.Crud.Configuration
 
             bool IfNotHandled(PredicateContext c) => !c.Handled;
 
+            bool ShouldValidate(DecoratorPredicateContext c) =>
+                typeof(ICrudRequestHandler).IsAssignableFrom(c.ImplementationType) &&
+                c.ImplementationType.RequestHasAttribute(typeof(ValidateAttribute));
+
+            Type ValidatorFactory(DecoratorPredicateContext c)
+            {
+                var tRequestHandler = c.ImplementationType
+                    .GetInterfaces()
+                    .Single(x => x.IsGenericType && (
+                        x.GetGenericTypeDefinition() == typeof(IRequestHandler<>) ||
+                        x.GetGenericTypeDefinition() == typeof(IRequestHandler<,>)));
+
+                var handlerArguments = tRequestHandler.GetGenericArguments();
+                var tRequest = handlerArguments[0];
+
+                ValidateAttribute FindAttribute(Type t)
+                {
+                    var attr = t.GetCustomAttribute<ValidateAttribute>(false);
+
+                    if (attr == null && t.BaseType != null)
+                        attr = FindAttribute(t.BaseType);
+
+                    if (attr == null)
+                    {
+                        foreach (var x in t.GetInterfaces())
+                        {
+                            attr = FindAttribute(x);
+                            if (attr != null) return attr;
+                        }
+                    }
+
+                    return attr;
+                }
+
+                var validateAttribute = FindAttribute(tRequest);
+                var tValidator = validateAttribute?.ValidatorType ?? 
+                    typeof(IValidator<>).MakeGenericType(tRequest);
+
+                if (handlerArguments.Length == 1)
+                    return typeof(CrudValidationDecorator<,>).MakeGenericType(tRequest, tValidator);
+
+                if (handlerArguments.Length == 2)
+                {
+                    var tResult = handlerArguments[1];
+                    return typeof(CrudValidationDecorator<,,>).MakeGenericType(tRequest, tResult, tValidator);
+                }
+                
+                return null;
+            }
+            
             container.RegisterInitializer<ICrudRequestHandler>(handler =>
             {
                 if (handler.ErrorDispatcher.Handler == null)
@@ -41,7 +94,7 @@ namespace Turner.Infrastructure.Crud.Configuration
             container.Register(typeof(CreateRequestHandler<,,>), configAssemblies);
             container.RegisterConditional(typeof(IRequestHandler<>), typeof(CreateRequestHandler<,>), IfNotHandled);
             container.RegisterConditional(typeof(IRequestHandler<,>), typeof(CreateRequestHandler<,,>), IfNotHandled);
-
+            
             container.Register(typeof(CreateAllRequestHandler<,>), configAssemblies);
             container.Register(typeof(CreateAllRequestHandler<,,>), configAssemblies);
             container.RegisterConditional(typeof(IRequestHandler<>), typeof(CreateAllRequestHandler<,>), IfNotHandled);
@@ -96,6 +149,9 @@ namespace Turner.Infrastructure.Crud.Configuration
             container.Register(typeof(SynchronizeRequestHandler<,,>), configAssemblies);
             container.RegisterConditional(typeof(IRequestHandler<>), typeof(SynchronizeRequestHandler<,>), IfNotHandled);
             container.RegisterConditional(typeof(IRequestHandler<,>), typeof(SynchronizeRequestHandler<,,>), IfNotHandled);
+
+            container.RegisterDecorator(typeof(IRequestHandler<>), ValidatorFactory, Lifestyle.Transient, ShouldValidate);
+            container.RegisterDecorator(typeof(IRequestHandler<,>), ValidatorFactory, Lifestyle.Transient, ShouldValidate);
         }
     }
 }

--- a/Turner.Infrastructure.Crud/CrudConfiguration.cs
+++ b/Turner.Infrastructure.Crud/CrudConfiguration.cs
@@ -13,6 +13,8 @@ namespace Turner.Infrastructure.Crud
 {
     public class CrudOptions
     {
+        public bool ValidateAllRequests { get; set; } = false;
+
         public bool UseFluentValidation { get; set; } = true;
     }
 
@@ -40,7 +42,7 @@ namespace Turner.Infrastructure.Crud
 
             bool ShouldValidate(DecoratorPredicateContext c) =>
                 typeof(ICrudRequestHandler).IsAssignableFrom(c.ImplementationType) &&
-                c.ImplementationType.RequestHasAttribute(typeof(ValidateAttribute));
+                (options.ValidateAllRequests || c.ImplementationType.RequestHasAttribute(typeof(ValidateAttribute)));
 
             Type ValidatorFactory(DecoratorPredicateContext c)
             {

--- a/Turner.Infrastructure.Crud/CrudConfiguration.cs
+++ b/Turner.Infrastructure.Crud/CrudConfiguration.cs
@@ -44,6 +44,7 @@ namespace Turner.Infrastructure.Crud
         {
             return c =>
                 typeof(ICrudRequestHandler).IsAssignableFrom(c.ImplementationType) &&
+                !c.ImplementationType.RequestHasAttribute(typeof(DoNotValidateAttribute)) &&
                 (options.ValidateAllRequests || c.ImplementationType.RequestHasAttribute(typeof(ValidateAttribute)));
         }
 
@@ -52,6 +53,7 @@ namespace Turner.Infrastructure.Crud
             var shouldValidate = ShouldValidate(options);
 
             return c => typeof(ICrudRequestHandler).IsAssignableFrom(c.ImplementationType) &&
+                !c.ImplementationType.RequestHasAttribute(typeof(DoNotValidateAttribute)) &&
                 !shouldValidate(c) &&
                 c.ImplementationType.RequestHasAttribute(typeof(MaybeValidateAttribute));
         }

--- a/Turner.Infrastructure.Crud/Requests/CreateAllDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/CreateAllDefaultRequests.cs
@@ -1,11 +1,12 @@
 ﻿using AutoMapper;
 using System.Collections.Generic;
 using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Validation;
 using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class CreateAllRequest<TEntity, TIn> : ICreateAllRequest<TEntity>
         where TEntity : class
     {
@@ -26,7 +27,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class CreateAllRequest<TEntity, TIn, TOut> : ICreateAllRequest<TEntity, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/CreateAllDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/CreateAllDefaultRequests.cs
@@ -2,11 +2,10 @@
 using System.Collections.Generic;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Validation;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class CreateAllRequest<TEntity, TIn> : ICreateAllRequest<TEntity>
         where TEntity : class
     {
@@ -27,7 +26,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class CreateAllRequest<TEntity, TIn, TOut> : ICreateAllRequest<TEntity, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/CreateAllRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/CreateAllRequestHandler.cs
@@ -1,5 +1,4 @@
 ﻿using AutoMapper;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/Turner.Infrastructure.Crud/Requests/CreateDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/CreateDefaultRequests.cs
@@ -1,11 +1,13 @@
 ﻿using AutoMapper;
 using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Validation;
 using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate]
-    public class CreateRequest<TEntity, TIn> : ICreateRequest<TEntity>
+    [DoNotValidate, MaybeValidate]
+    public class CreateRequest<TEntity, TIn> 
+        : ICreateRequest<TEntity>
         where TEntity : class
     {
         public CreateRequest(TIn item) { Item = item; }
@@ -24,8 +26,9 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
-    public class CreateRequest<TEntity, TIn, TOut> : ICreateRequest<TEntity, TOut>
+    [DoNotValidate, MaybeValidate]
+    public class CreateRequest<TEntity, TIn, TOut> 
+        : ICreateRequest<TEntity, TOut>
         where TEntity : class
     {
         public CreateRequest(TIn item) { Item = item; }

--- a/Turner.Infrastructure.Crud/Requests/CreateDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/CreateDefaultRequests.cs
@@ -1,11 +1,10 @@
 ﻿using AutoMapper;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Validation;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class CreateRequest<TEntity, TIn> 
         : ICreateRequest<TEntity>
         where TEntity : class
@@ -26,7 +25,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class CreateRequest<TEntity, TIn, TOut> 
         : ICreateRequest<TEntity, TOut>
         where TEntity : class

--- a/Turner.Infrastructure.Crud/Requests/CrudRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/CrudRequestHandler.cs
@@ -4,11 +4,6 @@ using Turner.Infrastructure.Crud.Errors;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    internal interface ICrudRequestHandler
-    {
-        CrudErrorDispatcher ErrorDispatcher { get; }
-    }
-
     internal abstract class CrudRequestHandler<TRequest, TEntity> : ICrudRequestHandler
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/DeleteAllDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/DeleteAllDefaultRequests.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Validation;
 using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class DeleteAllRequest<TEntity, TKey> : IDeleteAllRequest<TEntity>
         where TEntity : class
     {
@@ -14,7 +15,7 @@ namespace Turner.Infrastructure.Crud.Requests
         public List<TKey> Keys { get; }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class DeleteAllRequest<TEntity, TKey, TOut> : IDeleteAllRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -23,7 +24,7 @@ namespace Turner.Infrastructure.Crud.Requests
         public List<TKey> Keys { get; }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class DeleteAllByIdRequest<TEntity> : DeleteAllRequest<TEntity, int>
         where TEntity : class
     {
@@ -41,7 +42,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class DeleteAllByIdRequest<TEntity, TOut> : DeleteAllRequest<TEntity, int, TOut>
         where TEntity : class
     {
@@ -59,7 +60,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class DeleteAllByGuidRequest<TEntity> : DeleteAllRequest<TEntity, Guid>
         where TEntity : class
     {
@@ -77,7 +78,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class DeleteAllByGuidRequest<TEntity, TOut> : DeleteAllRequest<TEntity, Guid, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/DeleteAllDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/DeleteAllDefaultRequests.cs
@@ -2,11 +2,10 @@
 using System.Collections.Generic;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Validation;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class DeleteAllRequest<TEntity, TKey> : IDeleteAllRequest<TEntity>
         where TEntity : class
     {
@@ -15,7 +14,7 @@ namespace Turner.Infrastructure.Crud.Requests
         public List<TKey> Keys { get; }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class DeleteAllRequest<TEntity, TKey, TOut> : IDeleteAllRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -24,7 +23,7 @@ namespace Turner.Infrastructure.Crud.Requests
         public List<TKey> Keys { get; }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class DeleteAllByIdRequest<TEntity> : DeleteAllRequest<TEntity, int>
         where TEntity : class
     {
@@ -42,7 +41,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class DeleteAllByIdRequest<TEntity, TOut> : DeleteAllRequest<TEntity, int, TOut>
         where TEntity : class
     {
@@ -60,7 +59,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class DeleteAllByGuidRequest<TEntity> : DeleteAllRequest<TEntity, Guid>
         where TEntity : class
     {
@@ -78,7 +77,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class DeleteAllByGuidRequest<TEntity, TOut> : DeleteAllRequest<TEntity, Guid, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/DeleteDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/DeleteDefaultRequests.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Validation;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class DeleteRequest<TEntity, TKey> : IDeleteRequest<TEntity>
         where TEntity : class
     {
@@ -24,7 +23,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class DeleteRequest<TEntity, TKey, TOut> : IDeleteRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -43,7 +42,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class DeleteByIdRequest<TEntity>
         : DeleteRequest<TEntity, int>
         where TEntity : class
@@ -61,7 +60,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class DeleteByIdRequest<TEntity, TOut>
         : DeleteRequest<TEntity, int, TOut>
         where TEntity : class
@@ -79,7 +78,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class DeleteByGuidRequest<TEntity>
         : DeleteRequest<TEntity, Guid>
         where TEntity : class
@@ -97,7 +96,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class DeleteByGuidRequest<TEntity, TOut>
         : DeleteRequest<TEntity, Guid, TOut>
         where TEntity : class

--- a/Turner.Infrastructure.Crud/Requests/DeleteDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/DeleteDefaultRequests.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Validation;
 using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class DeleteRequest<TEntity, TKey> : IDeleteRequest<TEntity>
         where TEntity : class
     {
@@ -23,7 +24,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class DeleteRequest<TEntity, TKey, TOut> : IDeleteRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -42,7 +43,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class DeleteByIdRequest<TEntity>
         : DeleteRequest<TEntity, int>
         where TEntity : class
@@ -60,7 +61,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class DeleteByIdRequest<TEntity, TOut>
         : DeleteRequest<TEntity, int, TOut>
         where TEntity : class
@@ -78,7 +79,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class DeleteByGuidRequest<TEntity>
         : DeleteRequest<TEntity, Guid>
         where TEntity : class
@@ -96,7 +97,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class DeleteByGuidRequest<TEntity, TOut>
         : DeleteRequest<TEntity, Guid, TOut>
         where TEntity : class

--- a/Turner.Infrastructure.Crud/Requests/GetAllDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/GetAllDefaultRequests.cs
@@ -1,8 +1,9 @@
-﻿using Turner.Infrastructure.Mediator.Decorators;
+﻿using Turner.Infrastructure.Crud.Validation;
+using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class GetAllRequest<TEntity, TOut> : IGetAllRequest<TEntity, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/GetAllDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/GetAllDefaultRequests.cs
@@ -1,9 +1,8 @@
 ﻿using Turner.Infrastructure.Crud.Validation;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class GetAllRequest<TEntity, TOut> : IGetAllRequest<TEntity, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/GetDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/GetDefaultRequests.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Validation;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class GetRequest<TEntity, TKey, TOut> : IGetRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -24,7 +23,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class GetByIdRequest<TEntity, TOut> : GetRequest<TEntity, int, TOut>
         where TEntity : class
     {
@@ -41,7 +40,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class GetByGuidRequest<TEntity, TOut> : GetRequest<TEntity, Guid, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/GetDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/GetDefaultRequests.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Validation;
 using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class GetRequest<TEntity, TKey, TOut> : IGetRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -23,7 +24,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class GetByIdRequest<TEntity, TOut> : GetRequest<TEntity, int, TOut>
         where TEntity : class
     {
@@ -40,7 +41,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class GetByGuidRequest<TEntity, TOut> : GetRequest<TEntity, Guid, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/ICrudRequest.cs
+++ b/Turner.Infrastructure.Crud/Requests/ICrudRequest.cs
@@ -1,5 +1,8 @@
-﻿namespace Turner.Infrastructure.Crud.Requests
+﻿using Turner.Infrastructure.Mediator.Decorators;
+
+namespace Turner.Infrastructure.Crud.Requests
 {
+    [DoNotValidate]
     public interface ICrudRequest
     {
     }

--- a/Turner.Infrastructure.Crud/Requests/ICrudRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/ICrudRequestHandler.cs
@@ -1,0 +1,9 @@
+﻿using Turner.Infrastructure.Crud.Errors;
+
+namespace Turner.Infrastructure.Crud.Requests
+{
+    internal interface ICrudRequestHandler
+    {
+        CrudErrorDispatcher ErrorDispatcher { get; }
+    }
+}

--- a/Turner.Infrastructure.Crud/Requests/MergeDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/MergeDefaultRequests.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
 using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Validation;
 using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class MergeRequest<TEntity, TIn> : IMergeRequest<TEntity>
         where TEntity : class
     {
@@ -13,7 +14,7 @@ namespace Turner.Infrastructure.Crud.Requests
         public List<TIn> Items { get; }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class MergeByIdRequest<TEntity, TIn> : MergeRequest<TEntity, TIn>
         where TEntity : class
     {
@@ -32,7 +33,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class MergeByGuidRequest<TEntity, TIn> : MergeRequest<TEntity, TIn>
         where TEntity : class
     {
@@ -51,7 +52,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class MergeRequest<TEntity, TIn, TOut> : IMergeRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -60,7 +61,7 @@ namespace Turner.Infrastructure.Crud.Requests
         public List<TIn> Items { get; }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class MergeByIdRequest<TEntity, TIn, TOut> : MergeRequest<TEntity, TIn, TOut>
         where TEntity : class
     {
@@ -79,7 +80,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class MergeByGuidRequest<TEntity, TIn, TOut> : MergeRequest<TEntity, TIn, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/MergeDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/MergeDefaultRequests.cs
@@ -1,11 +1,10 @@
 ﻿using System.Collections.Generic;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Validation;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class MergeRequest<TEntity, TIn> : IMergeRequest<TEntity>
         where TEntity : class
     {
@@ -14,7 +13,7 @@ namespace Turner.Infrastructure.Crud.Requests
         public List<TIn> Items { get; }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class MergeByIdRequest<TEntity, TIn> : MergeRequest<TEntity, TIn>
         where TEntity : class
     {
@@ -33,7 +32,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class MergeByGuidRequest<TEntity, TIn> : MergeRequest<TEntity, TIn>
         where TEntity : class
     {
@@ -52,7 +51,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class MergeRequest<TEntity, TIn, TOut> : IMergeRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -61,7 +60,7 @@ namespace Turner.Infrastructure.Crud.Requests
         public List<TIn> Items { get; }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class MergeByIdRequest<TEntity, TIn, TOut> : MergeRequest<TEntity, TIn, TOut>
         where TEntity : class
     {
@@ -80,7 +79,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class MergeByGuidRequest<TEntity, TIn, TOut> : MergeRequest<TEntity, TIn, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/PagedFindDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/PagedFindDefaultRequests.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Validation;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
 #pragma warning disable 0618
 
     [Obsolete("Linq does not currently support positional queries. PagedFindRequest may cause a large result set to be created.")]
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class PagedFindRequest<TEntity, TKey, TOut> : IPagedFindRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -35,7 +34,7 @@ namespace Turner.Infrastructure.Crud.Requests
     }
 
     [Obsolete("Linq does not currently support positional queries. PagedFindRequest may cause a large result set to be created.")]
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class PagedFindByIdRequest<TEntity, TOut> : PagedFindRequest<TEntity, int, TOut>
         where TEntity : class
     {
@@ -56,7 +55,7 @@ namespace Turner.Infrastructure.Crud.Requests
     }
 
     [Obsolete("Linq does not currently support positional queries. PagedFindRequest may cause a large result set to be created.")]
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class PagedFindByGuidRequest<TEntity, TOut> : PagedFindRequest<TEntity, Guid, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/PagedFindDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/PagedFindDefaultRequests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Validation;
 using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
@@ -7,7 +8,7 @@ namespace Turner.Infrastructure.Crud.Requests
 #pragma warning disable 0618
 
     [Obsolete("Linq does not currently support positional queries. PagedFindRequest may cause a large result set to be created.")]
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class PagedFindRequest<TEntity, TKey, TOut> : IPagedFindRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -34,7 +35,7 @@ namespace Turner.Infrastructure.Crud.Requests
     }
 
     [Obsolete("Linq does not currently support positional queries. PagedFindRequest may cause a large result set to be created.")]
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class PagedFindByIdRequest<TEntity, TOut> : PagedFindRequest<TEntity, int, TOut>
         where TEntity : class
     {
@@ -55,7 +56,7 @@ namespace Turner.Infrastructure.Crud.Requests
     }
 
     [Obsolete("Linq does not currently support positional queries. PagedFindRequest may cause a large result set to be created.")]
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class PagedFindByGuidRequest<TEntity, TOut> : PagedFindRequest<TEntity, Guid, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/PagedGetAllDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/PagedGetAllDefaultRequests.cs
@@ -1,9 +1,8 @@
 ﻿using Turner.Infrastructure.Crud.Validation;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class PagedGetAllRequest<TEntity, TOut> : IPagedGetAllRequest<TEntity, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/PagedGetAllDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/PagedGetAllDefaultRequests.cs
@@ -1,8 +1,9 @@
-﻿using Turner.Infrastructure.Mediator.Decorators;
+﻿using Turner.Infrastructure.Crud.Validation;
+using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class PagedGetAllRequest<TEntity, TOut> : IPagedGetAllRequest<TEntity, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/PagedGetDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/PagedGetDefaultRequests.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Validation;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
 #pragma warning disable 0618
 
     [Obsolete("Linq does not currently support positional queries. PagedGetRequest may cause a large result set to be created.")]
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class PagedGetRequest<TEntity, TKey, TOut> : IPagedGetRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -34,7 +33,7 @@ namespace Turner.Infrastructure.Crud.Requests
     }
 
     [Obsolete("Linq does not currently support positional queries. PagedGetRequest may cause a large result set to be created.")]
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class PagedGetByIdRequest<TEntity, TOut>
         : PagedGetRequest<TEntity, int, TOut>
         where TEntity : class
@@ -56,7 +55,7 @@ namespace Turner.Infrastructure.Crud.Requests
     }
 
     [Obsolete("Linq does not currently support positional queries. PagedGetRequest may cause a large result set to be created.")]
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class PagedGetByGuidRequest<TEntity, TOut>
         : PagedGetRequest<TEntity, Guid, TOut>
         where TEntity : class

--- a/Turner.Infrastructure.Crud/Requests/PagedGetDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/PagedGetDefaultRequests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Validation;
 using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
@@ -7,7 +8,7 @@ namespace Turner.Infrastructure.Crud.Requests
 #pragma warning disable 0618
 
     [Obsolete("Linq does not currently support positional queries. PagedGetRequest may cause a large result set to be created.")]
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class PagedGetRequest<TEntity, TKey, TOut> : IPagedGetRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -33,7 +34,7 @@ namespace Turner.Infrastructure.Crud.Requests
     }
 
     [Obsolete("Linq does not currently support positional queries. PagedGetRequest may cause a large result set to be created.")]
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class PagedGetByIdRequest<TEntity, TOut>
         : PagedGetRequest<TEntity, int, TOut>
         where TEntity : class
@@ -55,7 +56,7 @@ namespace Turner.Infrastructure.Crud.Requests
     }
 
     [Obsolete("Linq does not currently support positional queries. PagedGetRequest may cause a large result set to be created.")]
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class PagedGetByGuidRequest<TEntity, TOut>
         : PagedGetRequest<TEntity, Guid, TOut>
         where TEntity : class

--- a/Turner.Infrastructure.Crud/Requests/SaveDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/SaveDefaultRequests.cs
@@ -2,11 +2,10 @@
 using System;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Validation;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class SaveRequest<TEntity, TIn> : ISaveRequest<TEntity>
         where TEntity : class
     {
@@ -27,7 +26,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class SaveRequest<TEntity, TIn, TOut> : ISaveRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -48,7 +47,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class SaveRequest<TEntity, TKey, TIn, TOut>
         : ISaveRequest<TEntity, TOut>
         where TEntity : class
@@ -77,7 +76,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class SaveByIdRequest<TEntity, TIn, TOut> : SaveRequest<TEntity, int, TIn, TOut>
         where TEntity : class
     {
@@ -94,7 +93,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class SaveByGuidRequest<TEntity, TIn, TOut> : SaveRequest<TEntity, Guid, TIn, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/SaveDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/SaveDefaultRequests.cs
@@ -1,11 +1,12 @@
 ﻿using AutoMapper;
 using System;
 using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Validation;
 using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class SaveRequest<TEntity, TIn> : ISaveRequest<TEntity>
         where TEntity : class
     {
@@ -26,7 +27,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class SaveRequest<TEntity, TIn, TOut> : ISaveRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -47,7 +48,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class SaveRequest<TEntity, TKey, TIn, TOut>
         : ISaveRequest<TEntity, TOut>
         where TEntity : class
@@ -76,7 +77,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class SaveByIdRequest<TEntity, TIn, TOut> : SaveRequest<TEntity, int, TIn, TOut>
         where TEntity : class
     {
@@ -93,7 +94,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class SaveByGuidRequest<TEntity, TIn, TOut> : SaveRequest<TEntity, Guid, TIn, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/SynchronizeDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/SynchronizeDefaultRequests.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
 using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Validation;
 using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class SynchronizeRequest<TEntity, TIn> : ISynchronizeRequest<TEntity>
         where TEntity : class
     {
@@ -13,7 +14,7 @@ namespace Turner.Infrastructure.Crud.Requests
         public List<TIn> Items { get; }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class SynchronizeByIdRequest<TEntity, TIn> : SynchronizeRequest<TEntity, TIn>
         where TEntity : class
     {
@@ -32,7 +33,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class SynchronizeByGuidRequest<TEntity, TIn> : SynchronizeRequest<TEntity, TIn>
         where TEntity : class
     {
@@ -51,7 +52,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class SynchronizeRequest<TEntity, TIn, TOut> : ISynchronizeRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -60,7 +61,7 @@ namespace Turner.Infrastructure.Crud.Requests
         public List<TIn> Items { get; }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class SynchronizeByIdRequest<TEntity, TIn, TOut> : SynchronizeRequest<TEntity, TIn, TOut>
         where TEntity : class
     {
@@ -79,7 +80,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class SynchronizeByGuidRequest<TEntity, TIn, TOut> : SynchronizeRequest<TEntity, TIn, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/SynchronizeDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/SynchronizeDefaultRequests.cs
@@ -1,11 +1,10 @@
 ﻿using System.Collections.Generic;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Validation;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class SynchronizeRequest<TEntity, TIn> : ISynchronizeRequest<TEntity>
         where TEntity : class
     {
@@ -14,7 +13,7 @@ namespace Turner.Infrastructure.Crud.Requests
         public List<TIn> Items { get; }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class SynchronizeByIdRequest<TEntity, TIn> : SynchronizeRequest<TEntity, TIn>
         where TEntity : class
     {
@@ -33,7 +32,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class SynchronizeByGuidRequest<TEntity, TIn> : SynchronizeRequest<TEntity, TIn>
         where TEntity : class
     {
@@ -52,7 +51,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class SynchronizeRequest<TEntity, TIn, TOut> : ISynchronizeRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -61,7 +60,7 @@ namespace Turner.Infrastructure.Crud.Requests
         public List<TIn> Items { get; }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class SynchronizeByIdRequest<TEntity, TIn, TOut> : SynchronizeRequest<TEntity, TIn, TOut>
         where TEntity : class
     {
@@ -80,7 +79,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class SynchronizeByGuidRequest<TEntity, TIn, TOut> : SynchronizeRequest<TEntity, TIn, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/UpdateAllDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/UpdateAllDefaultRequests.cs
@@ -1,11 +1,10 @@
 ﻿using System.Collections.Generic;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Validation;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class UpdateAllRequest<TEntity, TIn> : IUpdateAllRequest<TEntity>
         where TEntity : class
     {
@@ -14,7 +13,7 @@ namespace Turner.Infrastructure.Crud.Requests
         public List<TIn> Items { get; }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class UpdateAllByIdRequest<TEntity, TIn> : UpdateAllRequest<TEntity, TIn>
         where TEntity : class
     {
@@ -33,7 +32,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class UpdateAllByGuidRequest<TEntity, TIn> : UpdateAllRequest<TEntity, TIn>
         where TEntity : class
     {
@@ -52,7 +51,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class UpdateAllRequest<TEntity, TIn, TOut> : IUpdateAllRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -61,7 +60,7 @@ namespace Turner.Infrastructure.Crud.Requests
         public List<TIn> Items { get; }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class UpdateAllByIdRequest<TEntity, TIn, TOut> : UpdateAllRequest<TEntity, TIn, TOut>
         where TEntity : class
     {
@@ -80,7 +79,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class UpdateAllByGuidRequest<TEntity, TIn, TOut> : UpdateAllRequest<TEntity, TIn, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/UpdateAllDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/UpdateAllDefaultRequests.cs
@@ -1,10 +1,11 @@
 ﻿using System.Collections.Generic;
 using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Validation;
 using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class UpdateAllRequest<TEntity, TIn> : IUpdateAllRequest<TEntity>
         where TEntity : class
     {
@@ -13,7 +14,7 @@ namespace Turner.Infrastructure.Crud.Requests
         public List<TIn> Items { get; }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class UpdateAllByIdRequest<TEntity, TIn> : UpdateAllRequest<TEntity, TIn>
         where TEntity : class
     {
@@ -32,7 +33,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class UpdateAllByGuidRequest<TEntity, TIn> : UpdateAllRequest<TEntity, TIn>
         where TEntity : class
     {
@@ -51,7 +52,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class UpdateAllRequest<TEntity, TIn, TOut> : IUpdateAllRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -60,7 +61,7 @@ namespace Turner.Infrastructure.Crud.Requests
         public List<TIn> Items { get; }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class UpdateAllByIdRequest<TEntity, TIn, TOut> : UpdateAllRequest<TEntity, TIn, TOut>
         where TEntity : class
     {
@@ -79,7 +80,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class UpdateAllByGuidRequest<TEntity, TIn, TOut> : UpdateAllRequest<TEntity, TIn, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/UpdateDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/UpdateDefaultRequests.cs
@@ -1,11 +1,12 @@
 ﻿using AutoMapper;
 using System;
 using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Crud.Validation;
 using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class UpdateRequest<TEntity, TIn> : IUpdateRequest<TEntity>
         where TEntity : class
     {
@@ -25,7 +26,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class UpdateRequest<TEntity, TIn, TOut> : IUpdateRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -45,7 +46,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class UpdateRequest<TEntity, TKey, TIn, TOut>
         : IUpdateRequest<TEntity, TOut>
         where TEntity : class
@@ -72,7 +73,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class UpdateByIdRequest<TEntity, TIn, TOut> : UpdateRequest<TEntity, int, TIn, TOut>
         where TEntity : class
     {
@@ -90,7 +91,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate]
+    [DoNotValidate, MaybeValidate]
     public class UpdateByGuidRequest<TEntity, TIn, TOut> : UpdateRequest<TEntity, Guid, TIn, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Requests/UpdateDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/UpdateDefaultRequests.cs
@@ -2,11 +2,10 @@
 using System;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Validation;
-using Turner.Infrastructure.Mediator.Decorators;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class UpdateRequest<TEntity, TIn> : IUpdateRequest<TEntity>
         where TEntity : class
     {
@@ -26,7 +25,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class UpdateRequest<TEntity, TIn, TOut> : IUpdateRequest<TEntity, TOut>
         where TEntity : class
     {
@@ -46,7 +45,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class UpdateRequest<TEntity, TKey, TIn, TOut>
         : IUpdateRequest<TEntity, TOut>
         where TEntity : class
@@ -73,7 +72,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class UpdateByIdRequest<TEntity, TIn, TOut> : UpdateRequest<TEntity, int, TIn, TOut>
         where TEntity : class
     {
@@ -91,7 +90,7 @@ namespace Turner.Infrastructure.Crud.Requests
         }
     }
 
-    [DoNotValidate, MaybeValidate]
+    [MaybeValidate]
     public class UpdateByGuidRequest<TEntity, TIn, TOut> : UpdateRequest<TEntity, Guid, TIn, TOut>
         where TEntity : class
     {

--- a/Turner.Infrastructure.Crud/Validation/CrudDoNotValidateDecorator.cs
+++ b/Turner.Infrastructure.Crud/Validation/CrudDoNotValidateDecorator.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Turner.Infrastructure.Crud.Validation
+{
+    public class DoNotValidateAttribute : Attribute
+    {
+    }
+}

--- a/Turner.Infrastructure.Crud/Validation/CrudMaybeValidateDecorator.cs
+++ b/Turner.Infrastructure.Crud/Validation/CrudMaybeValidateDecorator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Requests;
 using Turner.Infrastructure.Mediator;

--- a/Turner.Infrastructure.Crud/Validation/CrudMaybeValidateDecorator.cs
+++ b/Turner.Infrastructure.Crud/Validation/CrudMaybeValidateDecorator.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Turner.Infrastructure.Crud.Requests;
+using Turner.Infrastructure.Mediator;
+
+namespace Turner.Infrastructure.Crud.Validation
+{
+    internal class MaybeValidateAttribute : Attribute
+    {
+    }
+
+    public class CrudMaybeValidateBaseDecorator<TRequest, TResponse>
+        where TResponse : Response, new()
+    {
+        private readonly ValidatorFactory _validatorFactory;
+
+        public CrudMaybeValidateBaseDecorator(ValidatorFactory validatorFactory)
+        {
+            _validatorFactory = validatorFactory;
+        }
+
+        public async Task<TResponse> HandleAsync(TRequest request, Func<Task<TResponse>> processRequest)
+        {
+            var validator = _validatorFactory.TryCreate<TRequest>();
+            if (validator == null)
+                return await processRequest();
+
+            var errors = await validator.ValidateAsync(request);
+            if (errors == null || errors.Count == 0)
+                return await processRequest();
+            
+            return new TResponse { Errors = errors };
+        }
+    }
+
+    public class CrudMaybeValidateDecorator<TRequest>
+        : IRequestHandler<TRequest>
+        where TRequest : IRequest, ICrudRequest
+    {
+        private readonly Func<IRequestHandler<TRequest>> _decorateeFactory;
+        private readonly CrudMaybeValidateBaseDecorator<TRequest, Response> _validationHandler;
+
+        public CrudMaybeValidateDecorator(Func<IRequestHandler<TRequest>> decorateeFactory,
+            CrudMaybeValidateBaseDecorator<TRequest, Response> validationHandler)
+        {
+            _decorateeFactory = decorateeFactory;
+            _validationHandler = validationHandler;
+        }
+
+        public Task<Response> HandleAsync(TRequest request)
+            => _validationHandler.HandleAsync(request, () => _decorateeFactory().HandleAsync(request));
+    }
+
+    public class CrudMaybeValidateDecorator<TRequest, TResult>
+        : IRequestHandler<TRequest, TResult>
+        where TRequest : IRequest<TResult>, ICrudRequest
+    {
+        private readonly Func<IRequestHandler<TRequest, TResult>> _decorateeFactory;
+        private readonly CrudMaybeValidateBaseDecorator<TRequest, Response<TResult>> _validationHandler;
+
+        public CrudMaybeValidateDecorator(Func<IRequestHandler<TRequest, TResult>> decorateeFactory,
+            CrudMaybeValidateBaseDecorator<TRequest, Response<TResult>> validationHandler)
+        {
+            _decorateeFactory = decorateeFactory;
+            _validationHandler = validationHandler;
+        }
+
+        public Task<Response<TResult>> HandleAsync(TRequest request)
+            => _validationHandler.HandleAsync(request, () => _decorateeFactory().HandleAsync(request));
+    }
+}

--- a/Turner.Infrastructure.Crud/Validation/CrudValidateDecorator.cs
+++ b/Turner.Infrastructure.Crud/Validation/CrudValidateDecorator.cs
@@ -32,13 +32,13 @@ namespace Turner.Infrastructure.Crud.Validation
         }
     }
     
-    public class CrudValidationBaseDecorator<TRequest, TResponse, TValidator> 
+    public class CrudValidateBaseDecorator<TRequest, TResponse, TValidator> 
         where TResponse : Response, new()
         where TValidator : IValidator<TRequest>
     {
         private readonly TValidator _validator;
 
-        public CrudValidationBaseDecorator(TValidator validator)
+        public CrudValidateBaseDecorator(TValidator validator)
         {
             _validator = validator;
         }
@@ -48,32 +48,21 @@ namespace Turner.Infrastructure.Crud.Validation
             var errors = await _validator.ValidateAsync(request);
             if (errors == null || errors.Count == 0)
                 return await processRequest();
-
-            var response = new TResponse
-            {
-                Errors = errors
-                    .Select(x => new Error
-                    {
-                        PropertyName = x.PropertyName,
-                        ErrorMessage = x.ErrorMessage
-                    })
-                    .ToList()
-            };
-
-            return response;
+            
+            return new TResponse { Errors = errors };
         }
     }
 
-    public class CrudValidationDecorator<TRequest, TValidator> 
+    public class CrudValidateDecorator<TRequest, TValidator> 
         : IRequestHandler<TRequest> 
         where TRequest : IRequest, ICrudRequest
         where TValidator : IValidator<TRequest>
     {
         private readonly Func<IRequestHandler<TRequest>> _decorateeFactory;
-        private readonly CrudValidationBaseDecorator<TRequest, Response, TValidator> _validationHandler;
+        private readonly CrudValidateBaseDecorator<TRequest, Response, TValidator> _validationHandler;
 
-        public CrudValidationDecorator(Func<IRequestHandler<TRequest>> decorateeFactory,
-            CrudValidationBaseDecorator<TRequest, Response, TValidator> validationHandler)
+        public CrudValidateDecorator(Func<IRequestHandler<TRequest>> decorateeFactory,
+            CrudValidateBaseDecorator<TRequest, Response, TValidator> validationHandler)
         {
             _decorateeFactory = decorateeFactory;
             _validationHandler = validationHandler;
@@ -83,16 +72,16 @@ namespace Turner.Infrastructure.Crud.Validation
             => _validationHandler.HandleAsync(request, () => _decorateeFactory().HandleAsync(request));
     }
 
-    public class CrudValidationDecorator<TRequest, TResult, TValidator> 
+    public class CrudValidateDecorator<TRequest, TResult, TValidator> 
         : IRequestHandler<TRequest, TResult> 
         where TRequest : IRequest<TResult>, ICrudRequest
         where TValidator : IValidator<TRequest>
     {
         private readonly Func<IRequestHandler<TRequest, TResult>> _decorateeFactory;
-        private readonly CrudValidationBaseDecorator<TRequest, Response<TResult>, TValidator> _validationHandler;
+        private readonly CrudValidateBaseDecorator<TRequest, Response<TResult>, TValidator> _validationHandler;
 
-        public CrudValidationDecorator(Func<IRequestHandler<TRequest, TResult>> decorateeFactory,
-            CrudValidationBaseDecorator<TRequest, Response<TResult>, TValidator> validationHandler)
+        public CrudValidateDecorator(Func<IRequestHandler<TRequest, TResult>> decorateeFactory,
+            CrudValidateBaseDecorator<TRequest, Response<TResult>, TValidator> validationHandler)
         {
             _decorateeFactory = decorateeFactory;
             _validationHandler = validationHandler;

--- a/Turner.Infrastructure.Crud/Validation/CrudValidationDecorator.cs
+++ b/Turner.Infrastructure.Crud/Validation/CrudValidationDecorator.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Turner.Infrastructure.Crud.Exceptions;
+using Turner.Infrastructure.Crud.Requests;
+using Turner.Infrastructure.Mediator;
+
+namespace Turner.Infrastructure.Crud.Validation
+{
+    public class ValidateAttribute : Attribute
+    {
+        public Type ValidatorType { get; }
+
+        public ValidateAttribute(Type validatorType)
+        {
+            if (validatorType != null && (
+                validatorType.IsGenericTypeDefinition ||
+                !validatorType.GetInterfaces().Any(
+                    x => x.IsGenericType && x.GetGenericTypeDefinition() == typeof(IValidator<>))))
+            {
+                string message = $"The type '{validatorType}' cannot be used for this attribute because " +
+                                 $"it is not a concrete type implementing the IValidator interface.";
+
+                throw new BadCrudConfigurationException(message);
+            }
+
+            ValidatorType = validatorType;
+        }
+
+        public ValidateAttribute() : this(null)
+        {
+        }
+    }
+
+    //internal class CrudValidationDecorator<TRequest, TValidator>
+    //    : IRequestHandler<TRequest>
+    //    where TRequest : IRequest, ICrudRequest
+    //    where TValidator : IValidator<TRequest>
+    //{
+    //    private readonly IRequestHandler<TRequest> _decoratee;
+    //    private readonly TValidator _validator;
+
+    //    public CrudValidationDecorator(IRequestHandler<TRequest> decoratee,
+    //        TValidator validator)
+    //    {
+    //        _decoratee = decoratee;
+    //        _validator = validator;
+    //    }
+
+    //    public async Task<Response> HandleAsync(TRequest request)
+    //    {
+    //        var errors = await _validator.ValidateAsync(request);
+    //        if (errors != null && errors.Count > 0)
+    //            return new Response { Errors = errors };
+
+    //        return await _decoratee.HandleAsync(request);
+    //    }
+    //}
+
+    //internal class CrudValidationDecorator<TRequest, TResult, TValidator>
+    //    : IRequestHandler<TRequest, TResult>
+    //    where TRequest : IRequest<TResult>, ICrudRequest
+    //    where TValidator : IValidator<TRequest>
+    //{
+    //    private readonly IRequestHandler<TRequest, TResult> _decoratee;
+    //    private readonly TValidator _validator;
+
+    //    public CrudValidationDecorator(IRequestHandler<TRequest, TResult> decoratee,
+    //        TValidator validator)
+    //    {
+    //        _decoratee = decoratee;
+    //        _validator = validator;
+    //    }
+
+    //    public async Task<Response<TResult>> HandleAsync(TRequest request)
+    //    {
+    //        var errors = await _validator.ValidateAsync(request);
+    //        if (errors != null && errors.Count > 0)
+    //            return new Response<TResult> { Errors = errors };
+
+    //        return await _decoratee.HandleAsync(request);
+    //    }
+    //}
+
+    public class CrudValidationBaseDecorator<TRequest, TResponse, TValidator> 
+        where TResponse : Response, new()
+        where TValidator : IValidator<TRequest>
+    {
+        private readonly TValidator _validator;
+
+        public CrudValidationBaseDecorator(TValidator validator)
+        {
+            _validator = validator;
+        }
+
+        public async Task<TResponse> HandleAsync(TRequest request, Func<Task<TResponse>> processRequest)
+        {
+            var errors = await _validator.ValidateAsync(request);
+            if (errors == null || errors.Count == 0)
+                return await processRequest();
+
+            var response = new TResponse
+            {
+                Errors = errors
+                    .Select(x => new Error
+                    {
+                        PropertyName = x.PropertyName,
+                        ErrorMessage = x.ErrorMessage
+                    })
+                    .ToList()
+            };
+
+            return response;
+        }
+    }
+
+    public class CrudValidationDecorator<TRequest, TValidator> 
+        : IRequestHandler<TRequest> 
+        where TRequest : IRequest, ICrudRequest
+        where TValidator : IValidator<TRequest>
+    {
+        private readonly Func<IRequestHandler<TRequest>> _decorateeFactory;
+        private readonly CrudValidationBaseDecorator<TRequest, Response, TValidator> _validationHandler;
+
+        public CrudValidationDecorator(Func<IRequestHandler<TRequest>> decorateeFactory,
+            CrudValidationBaseDecorator<TRequest, Response, TValidator> validationHandler)
+        {
+            _decorateeFactory = decorateeFactory;
+            _validationHandler = validationHandler;
+        }
+
+        public Task<Response> HandleAsync(TRequest request)
+            => _validationHandler.HandleAsync(request, () => _decorateeFactory().HandleAsync(request));
+    }
+
+    public class CrudValidationDecorator<TRequest, TResult, TValidator> 
+        : IRequestHandler<TRequest, TResult> 
+        where TRequest : IRequest<TResult>, ICrudRequest
+        where TValidator : IValidator<TRequest>
+    {
+        private readonly Func<IRequestHandler<TRequest, TResult>> _decorateeFactory;
+        private readonly CrudValidationBaseDecorator<TRequest, Response<TResult>, TValidator> _validationHandler;
+
+        public CrudValidationDecorator(Func<IRequestHandler<TRequest, TResult>> decorateeFactory,
+            CrudValidationBaseDecorator<TRequest, Response<TResult>, TValidator> validationHandler)
+        {
+            _decorateeFactory = decorateeFactory;
+            _validationHandler = validationHandler;
+        }
+
+        public Task<Response<TResult>> HandleAsync(TRequest request)
+            => _validationHandler.HandleAsync(request, () => _decorateeFactory().HandleAsync(request));
+    }
+}

--- a/Turner.Infrastructure.Crud/Validation/CrudValidationDecorator.cs
+++ b/Turner.Infrastructure.Crud/Validation/CrudValidationDecorator.cs
@@ -31,57 +31,7 @@ namespace Turner.Infrastructure.Crud.Validation
         {
         }
     }
-
-    //internal class CrudValidationDecorator<TRequest, TValidator>
-    //    : IRequestHandler<TRequest>
-    //    where TRequest : IRequest, ICrudRequest
-    //    where TValidator : IValidator<TRequest>
-    //{
-    //    private readonly IRequestHandler<TRequest> _decoratee;
-    //    private readonly TValidator _validator;
-
-    //    public CrudValidationDecorator(IRequestHandler<TRequest> decoratee,
-    //        TValidator validator)
-    //    {
-    //        _decoratee = decoratee;
-    //        _validator = validator;
-    //    }
-
-    //    public async Task<Response> HandleAsync(TRequest request)
-    //    {
-    //        var errors = await _validator.ValidateAsync(request);
-    //        if (errors != null && errors.Count > 0)
-    //            return new Response { Errors = errors };
-
-    //        return await _decoratee.HandleAsync(request);
-    //    }
-    //}
-
-    //internal class CrudValidationDecorator<TRequest, TResult, TValidator>
-    //    : IRequestHandler<TRequest, TResult>
-    //    where TRequest : IRequest<TResult>, ICrudRequest
-    //    where TValidator : IValidator<TRequest>
-    //{
-    //    private readonly IRequestHandler<TRequest, TResult> _decoratee;
-    //    private readonly TValidator _validator;
-
-    //    public CrudValidationDecorator(IRequestHandler<TRequest, TResult> decoratee,
-    //        TValidator validator)
-    //    {
-    //        _decoratee = decoratee;
-    //        _validator = validator;
-    //    }
-
-    //    public async Task<Response<TResult>> HandleAsync(TRequest request)
-    //    {
-    //        var errors = await _validator.ValidateAsync(request);
-    //        if (errors != null && errors.Count > 0)
-    //            return new Response<TResult> { Errors = errors };
-
-    //        return await _decoratee.HandleAsync(request);
-    //    }
-    //}
-
+    
     public class CrudValidationBaseDecorator<TRequest, TResponse, TValidator> 
         where TResponse : Response, new()
         where TValidator : IValidator<TRequest>

--- a/Turner.Infrastructure.Crud/Validation/FluentValidator.cs
+++ b/Turner.Infrastructure.Crud/Validation/FluentValidator.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Turner.Infrastructure.Mediator;
+
+namespace Turner.Infrastructure.Crud.Validation
+{
+    public class FluentValidator<TRequest> : IValidator<TRequest>
+    {
+        private readonly FluentValidation.IValidator<TRequest> _validator;
+
+        public FluentValidator(FluentValidation.IValidator<TRequest> validator)
+        {
+            _validator = validator;
+        }
+
+        public async Task<List<Error>> ValidateAsync(TRequest request, CancellationToken token = default(CancellationToken))
+        {
+            var validationResult = await _validator.ValidateAsync(request, token);
+            if (validationResult.IsValid)
+                return null;
+
+            return validationResult.Errors
+                .Select(error => new Error
+                {
+                    ErrorMessage = error.ErrorMessage,
+                    PropertyName = error.PropertyName
+                })
+                .ToList();
+        }
+    }
+}

--- a/Turner.Infrastructure.Crud/Validation/IValidator.cs
+++ b/Turner.Infrastructure.Crud/Validation/IValidator.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Turner.Infrastructure.Mediator;
+
+namespace Turner.Infrastructure.Crud.Validation
+{
+    public interface IValidator<TRequest>
+    {
+        Task<List<Error>> ValidateAsync(TRequest request, CancellationToken token = default(CancellationToken));
+    }
+}

--- a/Turner.Infrastructure.Crud/Validation/ValidatorFactory.cs
+++ b/Turner.Infrastructure.Crud/Validation/ValidatorFactory.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace Turner.Infrastructure.Crud.Validation
+{
+    public class ValidatorFactory
+    {
+        private readonly Func<Type, object> _validatorCreator;
+
+        public ValidatorFactory(Func<Type, object> creator)
+        {
+            _validatorCreator = creator;
+        }
+
+        public IValidator<TRequest> TryCreate<TRequest>()
+        {
+            try
+            {
+                return (IValidator<TRequest>)_validatorCreator(typeof(IValidator<TRequest>));
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Disabled (and replaced) Mediator validation for all `ICrudRequest` types
- Added support for opt-in and opt-out validation approaches
  - Opt-in is the default (no requests are validated except for those marked with `[Validate]`
- Added `[Validate]`, `[Validate(type)]`, `[DoNotValidate]` attributes
- Added validation support for generic requests:
  - For opt-in mode, generic requests will validate any time an `IValidator` is found parameterized on the request
  - For opt-out mode, generic requests will fail if no `IValidator` is found parameterized on the request
- When the `UseFluentValidation` option is true, all requests that don't have an `IValidator` registered for them will have one registered by default that will look for a FluentValidation `IValidator` (such as an `AbstractValidator` parameterized on the request)