### PR TITLE
Feat/async ct support

### DIFF
--- a/Turner.Infrastructure.Crud.Tests/HookTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/HookTests.cs
@@ -2,6 +2,7 @@
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Requests;
@@ -62,7 +63,7 @@ namespace Turner.Infrastructure.Crud.Tests
 
     public class TestInstanceRequestHook : IRequestHook<TestHooksRequest>
     {
-        public Task Run(TestHooksRequest request)
+        public Task Run(TestHooksRequest request, CancellationToken token)
         {
             request.Items.ForEach(i => i.RequestHookMessage += "r3/");
             return Task.CompletedTask;
@@ -71,7 +72,7 @@ namespace Turner.Infrastructure.Crud.Tests
 
     public class TestInstanceEntityHook : IEntityHook<TestHooksRequest, HookEntity>
     {
-        public Task Run(TestHooksRequest request, HookEntity entity)
+        public Task Run(TestHooksRequest request, HookEntity entity, CancellationToken token)
         {
             entity.EntityHookMessage += "e3/";
             return Task.CompletedTask;
@@ -80,7 +81,7 @@ namespace Turner.Infrastructure.Crud.Tests
 
     public class TestInstanceItemHook : IItemHook<TestHooksRequest, HookDto>
     {
-        public Task<HookDto> Run(TestHooksRequest request, HookDto item)
+        public Task<HookDto> Run(TestHooksRequest request, HookDto item, CancellationToken token)
         {
             item.ItemHookMessage += "i3/";
             return Task.FromResult(item);
@@ -89,7 +90,7 @@ namespace Turner.Infrastructure.Crud.Tests
 
     public class TestInstanceResultHook : IResultHook<TestHooksRequest, string>
     {
-        public Task<string> Run(TestHooksRequest request, string result)
+        public Task<string> Run(TestHooksRequest request, string result, CancellationToken token)
         {
             return Task.FromResult(result + "t3/");
         }
@@ -103,7 +104,7 @@ namespace Turner.Infrastructure.Crud.Tests
                 throw new System.Exception("Injection Failed");
         }
 
-        public Task Run(TestHooksRequest request)
+        public Task Run(TestHooksRequest request, CancellationToken token)
         {
             request.Items.ForEach(i => i.RequestHookMessage += "r4");
             return Task.CompletedTask;
@@ -118,7 +119,7 @@ namespace Turner.Infrastructure.Crud.Tests
                 throw new System.Exception("Injection Failed");
         }
 
-        public Task Run(TestHooksRequest request, HookEntity entity)
+        public Task Run(TestHooksRequest request, HookEntity entity, CancellationToken token)
         {
             entity.EntityHookMessage += "e4";
             return Task.CompletedTask;
@@ -133,7 +134,7 @@ namespace Turner.Infrastructure.Crud.Tests
                 throw new System.Exception("Injection Failed");
         }
 
-        public Task<HookDto> Run(TestHooksRequest request, HookDto item)
+        public Task<HookDto> Run(TestHooksRequest request, HookDto item, CancellationToken token)
         {
             item.ItemHookMessage += "i4";
             return Task.FromResult(item);
@@ -148,7 +149,7 @@ namespace Turner.Infrastructure.Crud.Tests
                 throw new System.Exception("Injection Failed");
         }
 
-        public Task<string> Run(TestHooksRequest request, string result)
+        public Task<string> Run(TestHooksRequest request, string result, CancellationToken token)
         {
             return Task.FromResult(result + "t4");
         }

--- a/Turner.Infrastructure.Crud/Components/Hook/Hook.cs
+++ b/Turner.Infrastructure.Crud/Components/Hook/Hook.cs
@@ -1,25 +1,27 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 
 namespace Turner.Infrastructure.Crud
 {
+    // TODO: Add defaults to the cts
     public interface IRequestHook<TRequest>
     {
-        Task Run(TRequest request);
+        Task Run(TRequest request, CancellationToken token);
     }
 
     public interface IEntityHook<TRequest, TEntity>
         where TEntity : class
     {
-        Task Run(TRequest request, TEntity entity);
+        Task Run(TRequest request, TEntity entity, CancellationToken token);
     }
 
     public interface IItemHook<TRequest, TItem>
     {
-        Task<TItem> Run(TRequest request, TItem item);
+        Task<TItem> Run(TRequest request, TItem item, CancellationToken token);
     }
 
     public interface IResultHook<TRequest, TResult>
     {
-        Task<TResult> Run(TRequest request, TResult result);
+        Task<TResult> Run(TRequest request, TResult result, CancellationToken token);
     }
 }

--- a/Turner.Infrastructure.Crud/Components/Hook/RequestHook.cs
+++ b/Turner.Infrastructure.Crud/Components/Hook/RequestHook.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Turner.Infrastructure.Crud
 {
     public interface IBoxedRequestHook
     {
-        Task Run(object request);
+        Task Run(object request, CancellationToken ct = default(CancellationToken));
     }
 
     public interface IRequestHookFactory
@@ -16,39 +17,43 @@ namespace Turner.Infrastructure.Crud
     public class FunctionRequestHook
         : IBoxedRequestHook
     {
-        private readonly Func<object, Task> _hookFunc;
+        private readonly Func<object, CancellationToken, Task> _hookFunc;
 
-        public FunctionRequestHook(Func<object, Task> hookFunc)
+        public FunctionRequestHook(Func<object, CancellationToken, Task> hookFunc)
         {
             _hookFunc = hookFunc;
         }
-
-        public Task Run(object request) => _hookFunc(request);
+        
+        public Task Run(object request, CancellationToken ct = default(CancellationToken)) => _hookFunc(request, ct);
     }
 
     public class FunctionRequestHookFactory : IRequestHookFactory
     {
         private readonly IBoxedRequestHook _hook;
 
-        private FunctionRequestHookFactory(Func<object, Task> hook)
+        private FunctionRequestHookFactory(Func<object, CancellationToken, Task> hook)
         {
             _hook = new FunctionRequestHook(hook);
         }
 
         internal static FunctionRequestHookFactory From<TRequest>(
-            Func<TRequest, Task> hook)
+            Func<TRequest, CancellationToken, Task> hook)
         {
             return new FunctionRequestHookFactory(
-                request => hook((TRequest)request));
+                (request, ct) => hook((TRequest)request, ct));
         }
 
         internal static FunctionRequestHookFactory From<TRequest>(
             Action<TRequest> hook)
         {
             return new FunctionRequestHookFactory(
-                request =>
+                (request, ct) =>
                 {
+                    if (ct.IsCancellationRequested)
+                        return Task.FromCanceled(ct);
+
                     hook((TRequest)request);
+
                     return Task.CompletedTask;
                 });
         }
@@ -72,7 +77,7 @@ namespace Turner.Infrastructure.Crud
         {
             return new InstanceRequestHookFactory(
                 hook,
-                new FunctionRequestHook(request => hook.Run((TRequest)request)));
+                new FunctionRequestHook((request, ct) => hook.Run((TRequest)request, ct)));
         }
 
         public IBoxedRequestHook Create() => _adaptedInstance;
@@ -101,7 +106,7 @@ namespace Turner.Infrastructure.Crud
                 () =>
                 {
                     var instance = (IRequestHook<TRequest>)s_serviceFactory(typeof(THook));
-                    return new FunctionRequestHook(request => instance.Run((TRequest)request));
+                    return new FunctionRequestHook((request, ct) => instance.Run((TRequest)request, ct));
                 });
         }
         

--- a/Turner.Infrastructure.Crud/Components/Hook/ResultHook.cs
+++ b/Turner.Infrastructure.Crud/Components/Hook/ResultHook.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Turner.Infrastructure.Crud
 {
     public interface IBoxedResultHook
     {
-        Task<object> Run(object request, object result);
+        Task<object> Run(object request, object result, CancellationToken ct = default(CancellationToken));
     }
 
     public interface IResultHookFactory
@@ -16,30 +17,31 @@ namespace Turner.Infrastructure.Crud
     public class FunctionResultHook
        : IBoxedResultHook
     {
-        private readonly Func<object, object, Task<object>> _hookFunc;
+        private readonly Func<object, object, CancellationToken, Task<object>> _hookFunc;
 
-        public FunctionResultHook(Func<object, object, Task<object>> hookFunc)
+        public FunctionResultHook(Func<object, object, CancellationToken, Task<object>> hookFunc)
         {
             _hookFunc = hookFunc;
         }
 
-        public Task<object> Run(object request, object result) => _hookFunc(request, result);
+        public Task<object> Run(object request, object result, CancellationToken ct) 
+            => _hookFunc(request, result, ct);
     }
 
     public class FunctionResultHookFactory : IResultHookFactory
     {
         private readonly IBoxedResultHook _hook;
 
-        private FunctionResultHookFactory(Func<object, object, Task<object>> hook)
+        private FunctionResultHookFactory(Func<object, object, CancellationToken, Task<object>> hook)
         {
             _hook = new FunctionResultHook(hook);
         }
 
         internal static FunctionResultHookFactory From<TRequest, TResult>(
-            Func<TRequest, TResult, Task<TResult>> hook)
+            Func<TRequest, TResult, CancellationToken, Task<TResult>> hook)
         {
             return new FunctionResultHookFactory(
-                (request, result) => hook((TRequest)request, (TResult)result)
+                (request, result, ct) => hook((TRequest)request, (TResult)result, ct)
                     .ContinueWith(t => (object)t.Result));
         }
 
@@ -47,7 +49,13 @@ namespace Turner.Infrastructure.Crud
             Func<TRequest, TResult, TResult> hook)
         {
             return new FunctionResultHookFactory(
-                (request, result) => Task.FromResult((object)hook((TRequest)request, (TResult)result)));
+                (request, result, ct) => 
+                {
+                    if (ct.IsCancellationRequested)
+                        return Task.FromCanceled<object>(ct);
+
+                    return Task.FromResult((object)hook((TRequest)request, (TResult)result));
+                });
         }
 
         public IBoxedResultHook Create() => _hook;
@@ -69,8 +77,8 @@ namespace Turner.Infrastructure.Crud
         {
             return new InstanceResultHookFactory(
                 hook,
-                new FunctionResultHook((request, result) => hook.Run((TRequest)request, (TResult)result)
-                    .ContinueWith(t => (object)t.Result)));
+                new FunctionResultHook((request, result, ct) 
+                    => hook.Run((TRequest)request, (TResult)result, ct).ContinueWith(t => (object)t.Result)));
         }
 
         public IBoxedResultHook Create() => _adaptedInstance;
@@ -99,8 +107,8 @@ namespace Turner.Infrastructure.Crud
                 () =>
                 {
                     var instance = (IResultHook<TRequest, TResult>)s_serviceFactory(typeof(THook));
-                    return new FunctionResultHook((request, result) 
-                        => instance.Run((TRequest)request, (TResult)result).ContinueWith(t => (object)t.Result));
+                    return new FunctionResultHook((request, result, ct) 
+                        => instance.Run((TRequest)request, (TResult)result, ct).ContinueWith(t => (object)t.Result));
                 });
         }
 

--- a/Turner.Infrastructure.Crud/Configuration/Builders/Entity/CrudRequestEntityConfigBuilderCommon.cs
+++ b/Turner.Infrastructure.Crud/Configuration/Builders/Entity/CrudRequestEntityConfigBuilderCommon.cs
@@ -162,7 +162,13 @@ namespace Turner.Infrastructure.Crud.Configuration.Builders
         public TBuilder CreateResultWith<TResult>(
             Func<TEntity, TResult> creator)
         {
-            CreateResult = entity => Task.FromResult((object)creator(entity));
+            CreateResult = (entity, ct) =>
+            {
+                if (ct.IsCancellationRequested)
+                    return Task.FromCanceled<object>(ct);
+
+                return Task.FromResult((object)creator(entity));
+            };
 
             return (TBuilder)this;
         }

--- a/Turner.Infrastructure.Crud/Configuration/CrudRequestProfile.cs
+++ b/Turner.Infrastructure.Crud/Configuration/CrudRequestProfile.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration.Builders;
 using Turner.Infrastructure.Crud.Exceptions;
@@ -97,10 +98,13 @@ namespace Turner.Infrastructure.Crud.Configuration
             RequestHooks.Add(InstanceRequestHookFactory.From(hook));
         }
 
-        protected void WithRequestHook(Func<TRequest, Task> hook)
+        protected void WithRequestHook(Func<TRequest, CancellationToken, Task> hook)
         {
             RequestHooks.Add(FunctionRequestHookFactory.From(hook));
         }
+
+        protected void WithRequestHook(Func<TRequest, Task> hook)
+            => WithRequestHook((request, ct) => hook(request));
 
         protected void WithRequestHook(Action<TRequest> hook)
         {
@@ -118,10 +122,13 @@ namespace Turner.Infrastructure.Crud.Configuration
             ResultHooks.Add(InstanceResultHookFactory.From(hook));
         }
 
-        protected void WithResultHook<TResult>(Func<TRequest, TResult, Task<TResult>> hook)
+        protected void WithResultHook<TResult>(Func<TRequest, TResult, CancellationToken, Task<TResult>> hook)
         {
             ResultHooks.Add(FunctionResultHookFactory.From(hook));
         }
+
+        protected void WithResultHook<TResult>(Func<TRequest, TResult, Task<TResult>> hook)
+            => WithResultHook<TResult>((request, result, ct) => hook(request, result));
 
         protected void WithResultHook<TResult>(Func<TRequest, TResult, TResult> hook)
         {

--- a/Turner.Infrastructure.Crud/Context/EFContext.cs
+++ b/Turner.Infrastructure.Crud/Context/EFContext.cs
@@ -23,11 +23,8 @@ namespace Turner.Infrastructure.Crud.Context
             return EFEntitySet<TEntity>.From(_context.Set<TEntity>());
         }
 
-        public virtual int ApplyChanges() => _context.SaveChanges();
-
         public virtual async Task<int> ApplyChangesAsync(CancellationToken token = default(CancellationToken))
         {
-            token.ThrowIfCancellationRequested();
             var result = await _context.SaveChangesAsync(token).Configure();
 
             token.ThrowIfCancellationRequested();

--- a/Turner.Infrastructure.Crud/Context/EFEntitySet.cs
+++ b/Turner.Infrastructure.Crud/Context/EFEntitySet.cs
@@ -33,20 +33,14 @@ namespace Turner.Infrastructure.Crud.Context
                 _set = set
             };
         }
-        
-        public virtual TEntity Create(TEntity entity) => _set.Add(entity).Entity;
-
-        public virtual TEntity[] Create(IEnumerable<TEntity> entities) => 
-            entities.Select(Create).ToArray();
-
-        public virtual async Task<TEntity> CreateAsync(TEntity entity,
+ 
+        public virtual Task<TEntity> CreateAsync(TEntity entity,
             CancellationToken token = default(CancellationToken))
         {
-            token.ThrowIfCancellationRequested();
-            var trackedEntity = await _set.AddAsync(entity, token).Configure();
+            var trackedEntity = _set.Add(entity);
 
             token.ThrowIfCancellationRequested();
-            return trackedEntity.Entity;
+            return Task.FromResult(trackedEntity.Entity);
         }
 
         public virtual async Task<TEntity[]> CreateAsync(IEnumerable<TEntity> entities,
@@ -56,17 +50,12 @@ namespace Turner.Infrastructure.Crud.Context
 
             foreach (var entity in entities)
             {
+                result.Add(await CreateAsync(entity, token));
                 token.ThrowIfCancellationRequested();
-                result.Add(await CreateAsync(entity));
             }
 
             return result.ToArray();
         }
-
-        public virtual TEntity Update(TEntity entity) => entity;
-
-        public virtual TEntity[] Update(IEnumerable<TEntity> entities) =>
-            entities.Select(Update).ToArray();
 
         public virtual Task<TEntity> UpdateAsync(TEntity entity,
             CancellationToken token = default(CancellationToken))
@@ -83,17 +72,12 @@ namespace Turner.Infrastructure.Crud.Context
 
             return Task.FromResult(entities.ToArray());
         }
-
-        public virtual TEntity Delete(TEntity entity) => _set.Remove(entity).Entity;
-
-        public virtual TEntity[] Delete(IEnumerable<TEntity> entities) =>
-            entities.Select(Delete).ToArray();
-
+        
         public virtual Task<TEntity> DeleteAsync(TEntity entity,
             CancellationToken token = default(CancellationToken))
         {
-            token.ThrowIfCancellationRequested();
             var trackedEntity = _set.Remove(entity);
+            token.ThrowIfCancellationRequested();
             
             return Task.FromResult(trackedEntity.Entity);
         }
@@ -105,8 +89,8 @@ namespace Turner.Infrastructure.Crud.Context
 
             foreach (var entity in entities)
             {
+                result.Add(await DeleteAsync(entity, token));
                 token.ThrowIfCancellationRequested();
-                result.Add(await DeleteAsync(entity));
             }
 
             return result.ToArray();

--- a/Turner.Infrastructure.Crud/Context/IEntityContext.cs
+++ b/Turner.Infrastructure.Crud/Context/IEntityContext.cs
@@ -11,8 +11,6 @@ namespace Turner.Infrastructure.Crud.Context
     {
         IEntitySet<TEntity> EntitySet<TEntity>() where TEntity : class;
 
-        int ApplyChanges();
-
         Task<int> ApplyChangesAsync(CancellationToken token = default(CancellationToken));
 
         Task<T> SingleOrDefaultAsync<T>(IQueryable<T> entities,

--- a/Turner.Infrastructure.Crud/Context/IEntitySet.cs
+++ b/Turner.Infrastructure.Crud/Context/IEntitySet.cs
@@ -7,25 +7,13 @@ namespace Turner.Infrastructure.Crud.Context
 {
     public interface IEntitySet<TEntity> : IQueryable<TEntity>
     {
-        TEntity Create(TEntity entity);
-
-        TEntity[] Create(IEnumerable<TEntity> entities);
-        
         Task<TEntity> CreateAsync(TEntity entity, CancellationToken token = default(CancellationToken));
 
         Task<TEntity[]> CreateAsync(IEnumerable<TEntity> entities, CancellationToken token = default(CancellationToken));
 
-        TEntity Update(TEntity entity);
-
-        TEntity[] Update(IEnumerable<TEntity> entities);
-
         Task<TEntity> UpdateAsync(TEntity entity, CancellationToken token = default(CancellationToken));
 
         Task<TEntity[]> UpdateAsync(IEnumerable<TEntity> entities, CancellationToken token = default(CancellationToken));
-
-        TEntity Delete(TEntity entity);
-
-        TEntity[] Delete(IEnumerable<TEntity> entities);
 
         Task<TEntity> DeleteAsync(TEntity entity, CancellationToken token = default(CancellationToken));
 

--- a/Turner.Infrastructure.Crud/Requests/PagedGetRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/PagedGetRequestHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Context;
@@ -9,7 +10,7 @@ using Turner.Infrastructure.Mediator;
 
 namespace Turner.Infrastructure.Crud.Requests
 {
-    #pragma warning disable 0618
+#pragma warning disable 0618
 
     internal class PagedGetRequestHandler<TRequest, TEntity, TOut>
         : CrudRequestHandler<TRequest, TEntity>, IRequestHandler<TRequest, PagedGetResult<TOut>>
@@ -27,80 +28,96 @@ namespace Turner.Infrastructure.Crud.Requests
         public async Task<Response<PagedGetResult<TOut>>> HandleAsync(TRequest request)
         {
             PagedGetResult<TOut> result;
-            var failedToFind = false;
 
-            try
+            using (var cts = new CancellationTokenSource())
             {
-                var requestHooks = RequestConfig.GetRequestHooks(request);
-                foreach (var hook in requestHooks)
-                    await hook.Run(request).Configure();
+                var ct = cts.Token;
+                var failedToFind = false;
 
-                var selector = RequestConfig.GetSelectorFor<TEntity>();
-                var entities = Context
-                    .EntitySet<TEntity>()
-                    .AsQueryable();
-
-                foreach (var filter in RequestConfig.GetFiltersFor<TEntity>())
-                    entities = filter.Filter(request, entities);
-
-                var sorter = RequestConfig.GetSorterFor<TEntity>();
-                entities = sorter?.Sort(request, entities) ?? entities;
-
-                var totalItemCount = await Context.CountAsync(entities).Configure();
-                var pageSize = request.PageSize < 1 ? totalItemCount : request.PageSize;
-                var totalPageCount = totalItemCount == 0 ? 1 : (totalItemCount + pageSize - 1) / pageSize;
-
-                var allItems = await Context.ToArrayAsync(entities).Configure();
-                var item = allItems
-                    .Select((e, i) => new { Item = e, Index = i })
-                    .SingleOrDefault(x => selector.Get<TEntity>()(request).Compile()(x.Item));
-
-                var transform = RequestConfig.GetResultCreatorFor<TEntity, TOut>();
-                var resultItems = new List<TOut>();
-                var pageNumber = 0;
-
-                if (item != null)
+                try
                 {
-                    var pageItems = allItems.Skip(item.Index / pageSize * pageSize).Take(pageSize);
-                    resultItems = new List<TOut>(await Task.WhenAll(pageItems.Select(transform)));
+                    var requestHooks = RequestConfig.GetRequestHooks(request);
+                    foreach (var hook in requestHooks)
+                        await hook.Run(request, ct).Configure();
 
-                    pageNumber = 1 + (item.Index / pageSize);
+                    ct.ThrowIfCancellationRequested();
+
+                    var selector = RequestConfig.GetSelectorFor<TEntity>();
+                    var entities = Context
+                        .EntitySet<TEntity>()
+                        .AsQueryable();
+
+                    foreach (var filter in RequestConfig.GetFiltersFor<TEntity>())
+                        entities = filter.Filter(request, entities);
+
+                    var sorter = RequestConfig.GetSorterFor<TEntity>();
+                    entities = sorter?.Sort(request, entities) ?? entities;
+
+                    var totalItemCount = await Context.CountAsync(entities, ct).Configure();
+                    ct.ThrowIfCancellationRequested();
+
+                    var pageSize = request.PageSize < 1 ? totalItemCount : request.PageSize;
+                    var totalPageCount = totalItemCount == 0 ? 1 : (totalItemCount + pageSize - 1) / pageSize;
+
+                    var allItems = await Context.ToArrayAsync(entities, ct).Configure();
+                    ct.ThrowIfCancellationRequested();
+
+                    var item = allItems
+                        .Select((e, i) => new { Item = e, Index = i })
+                        .SingleOrDefault(x => selector.Get<TEntity>()(request).Compile()(x.Item));
+
+                    var transform = RequestConfig.GetResultCreatorFor<TEntity, TOut>();
+                    var resultItems = new List<TOut>();
+                    var pageNumber = 0;
+
+                    if (item != null)
+                    {
+                        var pageItems = allItems.Skip(item.Index / pageSize * pageSize).Take(pageSize);
+                        resultItems = new List<TOut>(await Task.WhenAll(pageItems.Select(x => transform(x, ct))));
+                        ct.ThrowIfCancellationRequested();
+
+                        pageNumber = 1 + (item.Index / pageSize);
+                    }
+                    else
+                    {
+                        failedToFind = true;
+
+                        var defaultValue = RequestConfig.GetDefaultFor<TEntity>();
+                        if (defaultValue != null)
+                            resultItems.Add(await transform(defaultValue, ct).Configure());
+
+                        ct.ThrowIfCancellationRequested();
+
+                        pageNumber = 0;
+                    }
+
+                    var resultHooks = RequestConfig.GetResultHooks(request);
+                    foreach (var hook in resultHooks)
+                        for (var i = 0; i < resultItems.Count; ++i)
+                            resultItems[i] = (TOut)await hook.Run(request, resultItems[i], ct).Configure();
+
+                    ct.ThrowIfCancellationRequested();
+
+                    result = new PagedGetResult<TOut>
+                    {
+                        Items = resultItems,
+                        PageNumber = pageNumber,
+                        PageSize = pageSize,
+                        PageCount = totalPageCount,
+                        TotalItemCount = totalItemCount
+                    };
                 }
-                else
+                catch (CrudRequestFailedException e)
                 {
-                    failedToFind = true;
-
-                    var defaultValue = RequestConfig.GetDefaultFor<TEntity>();
-                    if (defaultValue != null)
-                        resultItems.Add(await transform(defaultValue).Configure());
-
-                    pageNumber = 0;
+                    var error = new RequestFailedError(request, e);
+                    return ErrorDispatcher.Dispatch<PagedGetResult<TOut>>(error);
                 }
 
-                var resultHooks = RequestConfig.GetResultHooks(request);
-                foreach (var hook in resultHooks)
-                    for (var i = 0; i < resultItems.Count; ++i)
-                        resultItems[i] = (TOut)await hook.Run(request, resultItems[i]).Configure();
-
-                result = new PagedGetResult<TOut>
+                if (failedToFind && RequestConfig.ErrorConfig.FailedToFindInFindIsError)
                 {
-                    Items = resultItems,
-                    PageNumber = pageNumber,
-                    PageSize = pageSize,
-                    PageCount = totalPageCount,
-                    TotalItemCount = totalItemCount
-                };
-            }
-            catch (CrudRequestFailedException e)
-            {
-                var error = new RequestFailedError(request, e);
-                return ErrorDispatcher.Dispatch<PagedGetResult<TOut>>(error);
-            }
-
-            if (failedToFind && RequestConfig.ErrorConfig.FailedToFindInFindIsError)
-            {
-                var error = new FailedToFindError(request, typeof(TEntity), result);
-                return ErrorDispatcher.Dispatch<PagedGetResult<TOut>>(error);
+                    var error = new FailedToFindError(request, typeof(TEntity), result);
+                    return ErrorDispatcher.Dispatch<PagedGetResult<TOut>>(error);
+                }
             }
 
             return result.AsResponse();

--- a/Turner.Infrastructure.Crud/Requests/SynchronizeRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/SynchronizeRequestHandler.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Context;
@@ -22,47 +23,58 @@ namespace Turner.Infrastructure.Crud.Requests
             Options = RequestConfig.GetOptionsFor<TEntity>();
         }
 
-        protected async Task<TEntity[]> SynchronizeEntities(TRequest request)
+        protected async Task<TEntity[]> SynchronizeEntities(TRequest request, CancellationToken ct)
         {
             var requestHooks = RequestConfig.GetRequestHooks(request);
             foreach (var hook in requestHooks)
-                await hook.Run(request).Configure();
-            
-            await DeleteEntities(request).Configure();
+                await hook.Run(request, ct).Configure();
 
-            var entities = await GetEntities(request).Configure();
-            
+            ct.ThrowIfCancellationRequested();
+
+            await DeleteEntities(request, ct).Configure();
+            ct.ThrowIfCancellationRequested();
+
+            var entities = await GetEntities(request, ct).Configure();
+            ct.ThrowIfCancellationRequested();
+
             var data = RequestConfig.GetRequestItemSourceFor<TEntity>();
             var items = ((IEnumerable<object>)data.ItemSource(request)).ToArray();
 
             var itemHooks = RequestConfig.GetItemHooksFor<TEntity>(request);
             foreach (var hook in itemHooks)
                 for (var i = 0; i < items.Length; ++i)
-                    items[i] = await hook.Run(request, items[i]).Configure();
+                    items[i] = await hook.Run(request, items[i], ct).Configure();
+
+            ct.ThrowIfCancellationRequested();
 
             var joinedItems = RequestConfig
                 .Join(items.Where(x => x != null), entities)
                 .ToArray();
 
             var createdEntities = await CreateEntities(
-                request, joinedItems.Length, joinedItems.Where(x => x.Item2 == null));
+                request, joinedItems.Length, joinedItems.Where(x => x.Item2 == null), ct);
+            ct.ThrowIfCancellationRequested();
 
             var updatedEntities = await UpdateEntities(
-                request, joinedItems.Length, joinedItems.Where(x => x.Item2 != null));
+                request, joinedItems.Length, joinedItems.Where(x => x.Item2 != null), ct);
+            ct.ThrowIfCancellationRequested();
 
             var changedEntities = updatedEntities.Concat(createdEntities).ToArray();
 
             var entityHooks = RequestConfig.GetEntityHooksFor<TEntity>(request);
             foreach (var entity in changedEntities)
                 foreach (var hook in entityHooks)
-                    await hook.Run(request, entity).Configure();
+                    await hook.Run(request, entity, ct).Configure();
 
-            await Context.ApplyChangesAsync().Configure();
+            ct.ThrowIfCancellationRequested();
+
+            await Context.ApplyChangesAsync(ct).Configure();
+            ct.ThrowIfCancellationRequested();
 
             return changedEntities;
         }
 
-        private Task DeleteEntities(TRequest request)
+        private Task DeleteEntities(TRequest request, CancellationToken ct)
         {
             var selector = RequestConfig.GetSelectorFor<TEntity>().Get<TEntity>();
             var entities = Context.EntitySet<TEntity>().AsQueryable();
@@ -77,42 +89,56 @@ namespace Turner.Infrastructure.Crud.Requests
 
             entities = entities.Where(notWhere);
 
-            return Context.EntitySet<TEntity>().DeleteAsync(entities);
+            return Context.EntitySet<TEntity>().DeleteAsync(entities, ct);
         }
 
-        private async Task<TEntity[]> GetEntities(TRequest request)
+        private async Task<TEntity[]> GetEntities(TRequest request, CancellationToken ct)
         {
             var selector = RequestConfig.GetSelectorFor<TEntity>().Get<TEntity>();
             var entities = Context.EntitySet<TEntity>().AsQueryable();
             
             entities = entities.Where(selector(request));
 
-            return await Context.ToArrayAsync(entities).Configure();
+            return await Context.ToArrayAsync(entities, ct).Configure();
         }
 
-        private async Task<TEntity[]> CreateEntities(TRequest request, int estimatedCount, IEnumerable<Tuple<object, TEntity>> items)
+        private async Task<TEntity[]> CreateEntities(TRequest request, 
+            int estimatedCount, 
+            IEnumerable<Tuple<object, TEntity>> items, 
+            CancellationToken ct)
         {
             var creator = RequestConfig.GetCreatorFor<TEntity>();
 
             var createdEntities = new List<TEntity>(estimatedCount);
             foreach (var item in items)
-                createdEntities.Add(await creator(request, item.Item1).Configure());
-            
-            var entities = await Context.EntitySet<TEntity>().CreateAsync(createdEntities).Configure();
-            
+            {
+                createdEntities.Add(await creator(request, item.Item1, ct).Configure());
+                ct.ThrowIfCancellationRequested();
+            }
+
+            var entities = await Context.EntitySet<TEntity>().CreateAsync(createdEntities, ct).Configure();
+            ct.ThrowIfCancellationRequested();
+
             return entities;
         }
 
-        private async Task<TEntity[]> UpdateEntities(TRequest request, int estimatedCount, IEnumerable<Tuple<object, TEntity>> items)
+        private async Task<TEntity[]> UpdateEntities(TRequest request, 
+            int estimatedCount, 
+            IEnumerable<Tuple<object, TEntity>> items,
+            CancellationToken ct)
         {
             var updator = RequestConfig.GetUpdatorFor<TEntity>();
 
             var updatedEntities = new List<TEntity>(estimatedCount);
             foreach (var item in items)
-                updatedEntities.Add(await updator(request, item.Item1, item.Item2).Configure());
-            
-            var entities = await Context.EntitySet<TEntity>().UpdateAsync(updatedEntities).Configure();
-            
+            {
+                updatedEntities.Add(await updator(request, item.Item1, item.Item2, ct).Configure());
+                ct.ThrowIfCancellationRequested();
+            }
+
+            var entities = await Context.EntitySet<TEntity>().UpdateAsync(updatedEntities, ct).Configure();
+            ct.ThrowIfCancellationRequested();
+
             return entities;
         }
     }
@@ -130,7 +156,8 @@ namespace Turner.Infrastructure.Crud.Requests
 
         public async Task<Response> HandleAsync(TRequest request)
         {
-            await SynchronizeEntities(request).Configure();
+            using (var cts = new CancellationTokenSource())
+                await SynchronizeEntities(request, cts.Token).Configure();
 
             return Response.Success();
         }
@@ -149,17 +176,28 @@ namespace Turner.Infrastructure.Crud.Requests
 
         public async Task<Response<SynchronizeResult<TOut>>> HandleAsync(TRequest request)
         {
-            var entities = await SynchronizeEntities(request).Configure();
+            SynchronizeResult<TOut> result;
 
-            var transform = RequestConfig.GetResultCreatorFor<TEntity, TOut>();
-            var items = new List<TOut>(await Task.WhenAll(entities.Select(transform)));
+            using (var cts = new CancellationTokenSource())
+            {
+                var ct = cts.Token;
 
-            var resultHooks = RequestConfig.GetResultHooks(request);
-            foreach (var hook in resultHooks)
-                for (var i = 0; i < items.Count; ++i)
-                    items[i] = (TOut)await hook.Run(request, items[i]).Configure();
+                var entities = await SynchronizeEntities(request, ct).Configure();
+                ct.ThrowIfCancellationRequested();
 
-            var result = new SynchronizeResult<TOut>(items);
+                var transform = RequestConfig.GetResultCreatorFor<TEntity, TOut>();
+                var items = new List<TOut>(await Task.WhenAll(entities.Select(x => transform(x, ct))));
+                ct.ThrowIfCancellationRequested();
+
+                var resultHooks = RequestConfig.GetResultHooks(request);
+                foreach (var hook in resultHooks)
+                    for (var i = 0; i < items.Count; ++i)
+                        items[i] = (TOut)await hook.Run(request, items[i], ct).Configure();
+
+                ct.ThrowIfCancellationRequested();
+
+                result = new SynchronizeResult<TOut>(items);
+            }
 
             return result.AsResponse();
         }

--- a/Turner.Infrastructure.Crud/Requests/UpdateAllRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/UpdateAllRequestHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Context;
@@ -19,13 +20,16 @@ namespace Turner.Infrastructure.Crud.Requests
             Options = RequestConfig.GetOptionsFor<TEntity>();
         }
         
-        protected async Task<TEntity[]> UpdateEntities(TRequest request)
+        protected async Task<TEntity[]> UpdateEntities(TRequest request, CancellationToken ct)
         {
             var requestHooks = RequestConfig.GetRequestHooks(request);
             foreach (var hook in requestHooks)
-                await hook.Run(request).Configure();
+                await hook.Run(request, ct).Configure();
 
-            var entities = await GetEntities(request).Configure();
+            ct.ThrowIfCancellationRequested();
+
+            var entities = await GetEntities(request, ct).Configure();
+            ct.ThrowIfCancellationRequested();
 
             var data = RequestConfig.GetRequestItemSourceFor<TEntity>();
             var items = ((IEnumerable<object>)data.ItemSource(request)).ToArray();
@@ -33,8 +37,10 @@ namespace Turner.Infrastructure.Crud.Requests
             var itemHooks = RequestConfig.GetItemHooksFor<TEntity>(request);
             foreach (var hook in itemHooks)
                 for (var i = 0; i < items.Length; ++i)
-                    items[i] = await hook.Run(request, items[i]).Configure();
-            
+                    items[i] = await hook.Run(request, items[i], ct).Configure();
+
+            ct.ThrowIfCancellationRequested();
+
             var updator = RequestConfig.GetUpdatorFor<TEntity>();
 
             var updatedEntities = new List<TEntity>(entities.Length);
@@ -43,22 +49,27 @@ namespace Turner.Infrastructure.Crud.Requests
                 if (item.Item1 == null || item.Item2 == null)
                     continue;
 
-                updatedEntities.Add(await updator(request, item.Item1, item.Item2).Configure());
+                updatedEntities.Add(await updator(request, item.Item1, item.Item2, ct).Configure());
+                ct.ThrowIfCancellationRequested();
             }
 
-            entities = await Context.EntitySet<TEntity>().UpdateAsync(updatedEntities).Configure();
+            entities = await Context.EntitySet<TEntity>().UpdateAsync(updatedEntities, ct).Configure();
+            ct.ThrowIfCancellationRequested();
 
             var entityHooks = RequestConfig.GetEntityHooksFor<TEntity>(request);
             foreach (var entity in updatedEntities)
                 foreach (var hook in entityHooks)
-                    await hook.Run(request, entity).Configure();
+                    await hook.Run(request, entity, ct).Configure();
 
-            await Context.ApplyChangesAsync().Configure();
+            ct.ThrowIfCancellationRequested();
+
+            await Context.ApplyChangesAsync(ct).Configure();
+            ct.ThrowIfCancellationRequested();
 
             return entities;
         }
 
-        private async Task<TEntity[]> GetEntities(TRequest request)
+        private async Task<TEntity[]> GetEntities(TRequest request, CancellationToken ct)
         {
             var selector = RequestConfig.GetSelectorFor<TEntity>().Get<TEntity>();
             var entities = Context.EntitySet<TEntity>().AsQueryable();
@@ -68,7 +79,7 @@ namespace Turner.Infrastructure.Crud.Requests
                 .GetFiltersFor<TEntity>()
                 .Aggregate(entities, (current, filter) => filter.Filter(request, current));
 
-            return await Context.ToArrayAsync(entities).Configure();
+            return await Context.ToArrayAsync(entities, ct).Configure();
         }
     }
 
@@ -86,7 +97,8 @@ namespace Turner.Infrastructure.Crud.Requests
 
         public async Task<Response> HandleAsync(TRequest request)
         {
-            await UpdateEntities(request).Configure();
+            using (var cts = new CancellationTokenSource())
+                await UpdateEntities(request, cts.Token).Configure();
 
             return Response.Success();
         }
@@ -106,17 +118,28 @@ namespace Turner.Infrastructure.Crud.Requests
 
         public async Task<Response<UpdateAllResult<TOut>>> HandleAsync(TRequest request)
         {
-            var entities = await UpdateEntities(request).Configure();
+            UpdateAllResult<TOut> result;
 
-            var transform = RequestConfig.GetResultCreatorFor<TEntity, TOut>();
-            var items = new List<TOut>(await Task.WhenAll(entities.Select(transform)));
+            using (var cts = new CancellationTokenSource())
+            {
+                var ct = cts.Token;
 
-            var resultHooks = RequestConfig.GetResultHooks(request);
-            foreach (var hook in resultHooks)
-                for (var i = 0; i < items.Count; ++i)
-                    items[i] = (TOut)await hook.Run(request, items[i]).Configure();
+                var entities = await UpdateEntities(request, ct).Configure();
+                ct.ThrowIfCancellationRequested();
 
-            var result = new UpdateAllResult<TOut>(items);
+                var transform = RequestConfig.GetResultCreatorFor<TEntity, TOut>();
+                var items = new List<TOut>(await Task.WhenAll(entities.Select(x => transform(x, ct))));
+                ct.ThrowIfCancellationRequested();
+
+                var resultHooks = RequestConfig.GetResultHooks(request);
+                foreach (var hook in resultHooks)
+                    for (var i = 0; i < items.Count; ++i)
+                        items[i] = (TOut)await hook.Run(request, items[i], ct).Configure();
+
+                ct.ThrowIfCancellationRequested();
+
+                result = new UpdateAllResult<TOut>(items);
+            }
 
             return result.AsResponse();
         }


### PR DESCRIPTION
- Added support for `CancellationToken` use to all requests and hooks
  - This support is useless at the moment since the Mediator doesn't currently support `CancellationToken`s
  - Support should (will?) be added to the Mediator