### PR TITLE
Feat/additional filters

### DIFF
--- a/Turner.Infrastructure.Crud/Configuration/Builders/FilterExtensions.cs
+++ b/Turner.Infrastructure.Crud/Configuration/Builders/FilterExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Linq.Expressions;
 using Turner.Infrastructure.Crud.Configuration.Builders;
 
@@ -53,6 +54,78 @@ namespace Turner.Infrastructure.Crud.Configuration
             where TEntity : class
         {
             return config.FilterWith(builder => builder.Using(filterFunc));
+        }
+
+        public static CrudRequestEntityConfigBuilder<TRequest, TEntity> FilterOn<TRequest, TEntity, TRequestProp, TEntityProp>(
+            this CrudRequestEntityConfigBuilder<TRequest, TEntity> config,
+            Expression<Func<TRequest, TRequestProp>> requestFilterExpr,
+            Expression<Func<TEntity, TEntityProp>> entityPropExpr)
+            where TEntity : class
+        {
+            return config.FilterWith(builder => builder.Using(CreateFilterFunc(requestFilterExpr, entityPropExpr)));
+        }
+
+        public static CrudBulkRequestEntityConfigBuilder<TRequest, TItem, TEntity> FilterOn<TRequest, TItem, TEntity, TRequestProp, TEntityProp>(
+            this CrudBulkRequestEntityConfigBuilder<TRequest, TItem, TEntity> config,
+            Expression<Func<TRequest, TRequestProp>> requestFilterExpr,
+            Expression<Func<TEntity, TEntityProp>> entityPropExpr)
+            where TEntity : class
+        {
+            return config.FilterWith(builder => builder.Using(CreateFilterFunc(requestFilterExpr, entityPropExpr)));
+        }
+
+        private static Func<TRequest, IQueryable<TEntity>, IQueryable<TEntity>> CreateFilterFunc<TRequest, TEntity, TRequestProp, TEntityProp>(
+            Expression<Func<TRequest, TRequestProp>> requestFilterExpr,
+            Expression<Func<TEntity, TEntityProp>> entityPropExpr)
+            where TEntity : class
+        {
+            bool isNullable = Nullable.GetUnderlyingType(typeof(TRequestProp)) != null;
+            bool isOptional = isNullable || !typeof(TRequestProp).IsValueType;
+
+            var rParamExpr = Expression.Parameter(typeof(TRequest));
+            var qParamExpr = Expression.Parameter(typeof(IQueryable<TEntity>));
+            var eParamExpr = Expression.Parameter(typeof(TEntity));
+
+            var ePropExpr = Expression.Invoke(entityPropExpr, eParamExpr);
+            var rFilterExpr = Expression.Invoke(requestFilterExpr, rParamExpr);
+            var rPropExpr = isNullable
+                ? Expression.Property(rFilterExpr, "Value")
+                : (Expression)rFilterExpr;
+
+            var compareExpr = Expression.Equal(rPropExpr, ePropExpr);
+            var whereClause = Expression.Lambda<Func<TEntity, bool>>(compareExpr, eParamExpr);
+
+            var whereInfo = typeof(Queryable)
+                .GetMethods()
+                .Single(x => x.Name == "Where"
+                    && x.GetParameters().Length == 2
+                    && x.GetParameters()[1].ParameterType.GetGenericArguments().Length == 1
+                    && x.GetParameters()[1].ParameterType.GetGenericArguments()[0].GetGenericArguments().Length == 2)
+                .MakeGenericMethod(typeof(TEntity));
+            
+            if (isOptional)
+            {
+                return Expression
+                    .Lambda<Func<TRequest, IQueryable<TEntity>, IQueryable<TEntity>>>(
+                        Expression.Condition(
+                            isNullable
+                                ? (Expression)Expression.Property(rFilterExpr, "HasValue")
+                                : Expression.NotEqual(rPropExpr, Expression.Constant(null, typeof(TRequestProp))),
+                            Expression.Call(whereInfo, qParamExpr, whereClause),
+                            qParamExpr),
+                        rParamExpr,
+                        qParamExpr)
+                    .Compile();
+            }
+            else
+            {
+                return Expression
+                    .Lambda<Func<TRequest, IQueryable<TEntity>, IQueryable<TEntity>>>(
+                        Expression.Call(whereInfo, qParamExpr, whereClause),
+                        rParamExpr,
+                        qParamExpr)
+                    .Compile();
+            }
         }
     }
 }

--- a/Turner.Infrastructure.Crud/CrudConfiguration.cs
+++ b/Turner.Infrastructure.Crud/CrudConfiguration.cs
@@ -173,10 +173,13 @@ namespace Turner.Infrastructure.Crud
             var shouldValidate = ShouldValidate(options.ValidateAllRequests);
             var shouldMaybeValidate = ShouldMaybeValidate(options.ValidateAllRequests);
 
+            container.RegisterInstance(new ValidatorFactory(container.GetInstance));
+
+            container.Register(typeof(IRequestValidator<>), assemblies);
+
             container.RegisterDecorator(typeof(IRequestHandler<>), ValidatorFactory, Lifestyle.Transient, shouldValidate);
             container.RegisterDecorator(typeof(IRequestHandler<,>), ValidatorFactory, Lifestyle.Transient, shouldValidate);
 
-            container.RegisterInstance(new ValidatorFactory(container.GetInstance));
             container.RegisterDecorator(typeof(IRequestHandler<>), typeof(CrudMaybeValidateDecorator<>), shouldMaybeValidate);
             container.RegisterDecorator(typeof(IRequestHandler<,>), typeof(CrudMaybeValidateDecorator<,>), shouldMaybeValidate);
         }

--- a/Turner.Infrastructure.Crud/Validation/ValidatorFactory.cs
+++ b/Turner.Infrastructure.Crud/Validation/ValidatorFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using SimpleInjector;
 
 namespace Turner.Infrastructure.Crud.Validation
 {
@@ -17,7 +18,7 @@ namespace Turner.Infrastructure.Crud.Validation
             {
                 return (IRequestValidator<TRequest>)_validatorCreator(typeof(IRequestValidator<TRequest>));
             }
-            catch
+            catch(ActivationException)
             {
                 return null;
             }


### PR DESCRIPTION
- Added additional `FilterOn` func to build simple equality filters
  - If the request property is a reference type, the filter is not invoked when its value is null
  - If the request property is a nullable type, the filter is not invoked when its value is null