### PR TITLE
feat(universal profiles): add universal profiles and result hook adap…

### DIFF
--- a/Turner.Infrastructure.Crud.Tests/HookTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/HookTests.cs
@@ -71,7 +71,11 @@ namespace Turner.Infrastructure.Crud.Tests
                 return Task.CompletedTask;
             });
 
-            AddResultHook<string>((r, t) => "t1/");
+            AddResultHook<CreateAllResult<string>>((r, t) =>
+            {
+                return new CreateAllResult<string>(t.Items.Select(x => "t1/"));
+            });
+
             AddResultHook<string>((r, t) => Task.FromResult(t + "t2/"));
 
             ForEntity<IHookEntity>()

--- a/Turner.Infrastructure.Crud.Tests/UniversalProfileTests.cs
+++ b/Turner.Infrastructure.Crud.Tests/UniversalProfileTests.cs
@@ -1,0 +1,95 @@
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
+using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Mediator;
+using Turner.Infrastructure.Mediator.Decorators;
+
+namespace Turner.Infrastructure.Crud.Tests
+{
+    [TestFixture]
+    public class UniversalProfileTests : BaseUnitTest
+    {
+        [Test]
+        public async Task Handle_NonCrudRequest_RunsHooksInCorrectOrder()
+        {
+            var request = new TestUniversalRequest
+            {
+                RequestHookMessage = string.Empty
+            };
+
+            var response = await Mediator.HandleAsync(request);
+
+            Assert.IsFalse(response.HasErrors);
+
+            Assert.NotNull(response.Data);
+            Assert.AreEqual("r1/r2", response.Data.RequestHookMessage);
+            Assert.AreEqual("t1/t2/t3", response.Data.ResultHookMessage);
+        }
+    }
+
+    public class UniversalDto
+    {
+        public string RequestHookMessage { get; set; }
+
+        public string ResultHookMessage { get; set; }
+    }
+    
+    [DoNotValidate]
+    public class TestUniversalRequest : IRequest<UniversalDto>
+    {
+        public string RequestHookMessage { get; set; }
+    }
+
+    public class TestUniversalRequestHandler : IRequestHandler<TestUniversalRequest, UniversalDto>
+    {
+        public Task<Response<UniversalDto>> HandleAsync(TestUniversalRequest request)
+        {
+            var result = new UniversalDto { RequestHookMessage = request.RequestHookMessage };
+            return result.AsResponseAsync();
+        }
+    }
+    
+    public class TestUniversalProfile
+        : UniversalRequestProfile<TestUniversalRequest>
+    {
+        public TestUniversalProfile()
+        {
+            AddRequestHook(r =>
+            {
+                r.RequestHookMessage = "r1/";
+            });
+
+            AddRequestHook(r =>
+            {
+                r.RequestHookMessage += "r2";
+                return Task.CompletedTask;
+            });
+
+            AddResultHook<UniversalDto>((r, t) => 
+            {
+                t.ResultHookMessage += "t2/";
+                return t;
+            });
+
+            AddResultHook<UniversalDto>((r, t) => 
+            {
+                t.ResultHookMessage += "t3";
+                return Task.FromResult(t);
+            });
+        }
+    }
+
+    public class TestProfile<T> : UniversalRequestProfile<IRequest<T>>
+    {
+        public TestProfile()
+        {
+            AddResultHook<T>((request, result) =>
+            {
+                if (request is TestUniversalRequest testRequest)
+                    (result as UniversalDto).ResultHookMessage = "t1/";
+                    
+                return result;
+            });
+        }
+    }
+}

--- a/Turner.Infrastructure.Crud/Components/Hook/ResultHookAdapter.cs
+++ b/Turner.Infrastructure.Crud/Components/Hook/ResultHookAdapter.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Turner.Infrastructure.Crud.Exceptions;
+using Turner.Infrastructure.Crud.Requests;
+
+namespace Turner.Infrastructure.Crud
+{
+    internal static class ResultHookAdapter
+    {
+        internal static async Task<T> Adapt<T>(IBoxedResultHook hook,
+            object request,
+            T result,
+            CancellationToken ct)
+        {
+            if (typeof(IResultCollection<>).MakeGenericType(hook.ResultType).IsAssignableFrom(typeof(T)))
+            {
+                var adaptMethod = typeof(ResultHookAdapter)
+                    .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+                    .Single(x => x.Name == "AdaptAsCollection");
+
+                await (Task)adaptMethod
+                    .MakeGenericMethod(hook.ResultType)
+                    .Invoke(null, new object[] { hook, request, result, ct });
+
+                return result;
+            }
+
+            throw new BadCrudConfigurationException($"Failed to adapt hook result type {typeof(T)}");
+        }
+
+        internal static async Task AdaptAsCollection<T>(IBoxedResultHook hook,
+            object request,
+            IResultCollection<T> items,
+            CancellationToken ct)
+        {
+            var result = new List<T>(items.Items.Count);
+
+            foreach (var item in items.Items)
+                result.Add((T)await hook.Run(request, item, ct));
+
+            items.Items = result;
+        }
+    }
+}

--- a/Turner.Infrastructure.Crud/Configuration/CrudBulkRequestProfile.cs
+++ b/Turner.Infrastructure.Crud/Configuration/CrudBulkRequestProfile.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using Turner.Infrastructure.Crud.Configuration.Builders;
+using Turner.Infrastructure.Crud.Requests;
+
+namespace Turner.Infrastructure.Crud.Configuration
+{
+    public abstract class CrudBulkRequestProfile<TRequest, TItem>
+        : CrudRequestProfileCommon<TRequest>
+        where TRequest : ICrudRequest, IBulkRequest
+    {
+        private readonly Expression<Func<TRequest, IEnumerable<TItem>>> _defaultItemSource;
+
+        public CrudBulkRequestProfile()
+        {
+        }
+
+        public CrudBulkRequestProfile(Expression<Func<TRequest, IEnumerable<TItem>>> defaultItemSource)
+        {
+            _defaultItemSource = defaultItemSource;
+        }
+
+        protected CrudBulkRequestEntityConfigBuilder<TRequest, TItem, TEntity> ForEntity<TEntity>()
+            where TEntity : class
+        {
+            var builder = new CrudBulkRequestEntityConfigBuilder<TRequest, TItem, TEntity>();
+
+            if (_defaultItemSource != null)
+                builder.WithRequestItems(_defaultItemSource);
+
+            _requestEntityBuilders[typeof(TEntity)] = builder;
+
+            return builder;
+        }
+    }
+
+    public class DefaultBulkCrudRequestProfile<TRequest> : CrudBulkRequestProfile<TRequest, TRequest>
+        where TRequest : ICrudRequest, IBulkRequest
+    {
+    }
+}

--- a/Turner.Infrastructure.Crud/Requests/CreateAllDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/CreateAllDefaultRequests.cs
@@ -9,9 +9,11 @@ namespace Turner.Infrastructure.Crud.Requests
     public class CreateAllRequest<TEntity, TIn> : ICreateAllRequest<TEntity>
         where TEntity : class
     {
-        public CreateAllRequest(List<TIn> items) { Items = items; }
+        public List<TIn> Items { get; set; } = new List<TIn>();
 
-        public List<TIn> Items { get; }
+        public CreateAllRequest() { }
+
+        public CreateAllRequest(List<TIn> items) { Items = items; }
     }
 
     public class CreateAllRequestProfile<TEntity, TIn>
@@ -30,9 +32,11 @@ namespace Turner.Infrastructure.Crud.Requests
     public class CreateAllRequest<TEntity, TIn, TOut> : ICreateAllRequest<TEntity, TOut>
         where TEntity : class
     {
-        public CreateAllRequest(List<TIn> items) { Items = items; }
+        public List<TIn> Items { get; set; } = new List<TIn>();
 
-        public List<TIn> Items { get; }
+        public CreateAllRequest() { }
+
+        public CreateAllRequest(List<TIn> items) { Items = items; }
     }
 
     public class CreateAllRequestProfile<TEntity, TIn, TOut>

--- a/Turner.Infrastructure.Crud/Requests/CreateAllRequest.cs
+++ b/Turner.Infrastructure.Crud/Requests/CreateAllRequest.cs
@@ -19,9 +19,9 @@ namespace Turner.Infrastructure.Crud.Requests
     {
     }
 
-    public class CreateAllResult<TOut>
+    public class CreateAllResult<TOut> : IResultCollection<TOut>
     {
-        public List<TOut> Items { get; }
+        public List<TOut> Items { get; set; }
 
         public CreateAllResult(IEnumerable<TOut> items)
         {

--- a/Turner.Infrastructure.Crud/Requests/CreateAllRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/CreateAllRequestHandler.cs
@@ -79,10 +79,10 @@ namespace Turner.Infrastructure.Crud.Requests
         private async Task<CreateAllResult<TOut>> HandleAsync(TRequest request, CancellationToken token)
         {
             var entities = await CreateEntities(request, token).Configure();
-            var tOuts = await entities.CreateResults<TEntity, TOut>(RequestConfig, token).Configure();
-            var items = await request.RunResultHooks(RequestConfig, tOuts, token).Configure();
+            var items = await entities.CreateResults<TEntity, TOut>(RequestConfig, token).Configure();
+            var result = new CreateAllResult<TOut>(items);
 
-            return new CreateAllResult<TOut>(items);
+            return await request.RunResultHooks(RequestConfig, result, token).Configure();
         }
     }
 }

--- a/Turner.Infrastructure.Crud/Requests/CreateDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/CreateDefaultRequests.cs
@@ -9,9 +9,11 @@ namespace Turner.Infrastructure.Crud.Requests
         : ICreateRequest<TEntity>
         where TEntity : class
     {
-        public CreateRequest(TIn item) { Item = item; }
+        public TIn Item { get; set; }
 
-        public TIn Item { get; }
+        public CreateRequest() { }
+
+        public CreateRequest(TIn item) { Item = item; }
     }
 
     public class CreateRequestProfile<TEntity, TIn>
@@ -30,9 +32,11 @@ namespace Turner.Infrastructure.Crud.Requests
         : ICreateRequest<TEntity, TOut>
         where TEntity : class
     {
-        public CreateRequest(TIn item) { Item = item; }
+        public TIn Item { get; set; }
 
-        public TIn Item { get; }
+        public CreateRequest() { }
+
+        public CreateRequest(TIn item) { Item = item; }
     }
 
     public class CreateRequestProfile<TEntity, TIn, TOut>

--- a/Turner.Infrastructure.Crud/Requests/DeleteAllDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/DeleteAllDefaultRequests.cs
@@ -9,9 +9,11 @@ namespace Turner.Infrastructure.Crud.Requests
     public class DeleteAllRequest<TEntity, TKey> : IDeleteAllRequest<TEntity>
         where TEntity : class
     {
-        public DeleteAllRequest(List<TKey> keys) { Keys = keys; }
+        public List<TKey> Keys { get; set; } = new List<TKey>();
 
-        public List<TKey> Keys { get; }
+        public DeleteAllRequest() { }
+
+        public DeleteAllRequest(List<TKey> keys) { Keys = keys; }
     }
 
     [MaybeValidate]

--- a/Turner.Infrastructure.Crud/Requests/DeleteAllRequest.cs
+++ b/Turner.Infrastructure.Crud/Requests/DeleteAllRequest.cs
@@ -19,9 +19,9 @@ namespace Turner.Infrastructure.Crud.Requests
     {
     }
 
-    public class DeleteAllResult<TOut>
+    public class DeleteAllResult<TOut> : IResultCollection<TOut>
     {
-        public List<TOut> Items { get; }
+        public List<TOut> Items { get; set; }
 
         public DeleteAllResult(IEnumerable<TOut> items)
         {

--- a/Turner.Infrastructure.Crud/Requests/DeleteAllRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/DeleteAllRequestHandler.cs
@@ -81,10 +81,10 @@ namespace Turner.Infrastructure.Crud.Requests
         private async Task<DeleteAllResult<TOut>> HandleAsync(TRequest request, CancellationToken token)
         {
             var entities = await DeleteEntities(request, token).Configure();
-            var tOuts = await entities.CreateResults<TEntity, TOut>(RequestConfig, token).Configure();
-            var items = await request.RunResultHooks(RequestConfig, tOuts, token).Configure();
+            var items = await entities.CreateResults<TEntity, TOut>(RequestConfig, token).Configure();
+            var result = new DeleteAllResult<TOut>(items);
 
-            return new DeleteAllResult<TOut>(items);
+            return await request.RunResultHooks(RequestConfig, result, token).Configure();
         }
     }
 }

--- a/Turner.Infrastructure.Crud/Requests/DeleteDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/DeleteDefaultRequests.cs
@@ -8,9 +8,11 @@ namespace Turner.Infrastructure.Crud.Requests
     public class DeleteRequest<TEntity, TKey> : IDeleteRequest<TEntity>
         where TEntity : class
     {
-        public DeleteRequest(TKey key) { Key = key; }
+        public TKey Key { get; set; }
 
-        public TKey Key { get; }
+        public DeleteRequest() { }
+
+        public DeleteRequest(TKey key) { Key = key; }
     }
 
     public class DeleteRequestProfile<TEntity, TKey>
@@ -27,9 +29,9 @@ namespace Turner.Infrastructure.Crud.Requests
     public class DeleteRequest<TEntity, TKey, TOut> : IDeleteRequest<TEntity, TOut>
         where TEntity : class
     {
-        public DeleteRequest(TKey key) { Key = key; }
+        public TKey Key { get; set; }
 
-        public TKey Key { get; }
+        public DeleteRequest(TKey key) { Key = key; }
     }
 
     public class DeleteRequestProfile<TEntity, TKey, TOut>

--- a/Turner.Infrastructure.Crud/Requests/GetAllRequest.cs
+++ b/Turner.Infrastructure.Crud/Requests/GetAllRequest.cs
@@ -14,9 +14,9 @@ namespace Turner.Infrastructure.Crud.Requests
     {
     }
     
-    public class GetAllResult<TOut>
+    public class GetAllResult<TOut> : IResultCollection<TOut>
     {
-        public List<TOut> Items { get; }
+        public List<TOut> Items { get; set; }
 
         public GetAllResult(IEnumerable<TOut> items)
         {

--- a/Turner.Infrastructure.Crud/Requests/GetDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/GetDefaultRequests.cs
@@ -8,9 +8,11 @@ namespace Turner.Infrastructure.Crud.Requests
     public class GetRequest<TEntity, TKey, TOut> : IGetRequest<TEntity, TOut>
         where TEntity : class
     {
-        public GetRequest(TKey key) { Key = key; }
+        public TKey Key { get; set; }
 
-        public TKey Key { get; }
+        public GetRequest() { }
+
+        public GetRequest(TKey key) { Key = key; }
     }
 
     public class GetRequestProfile<TEntity, TKey, TOut>

--- a/Turner.Infrastructure.Crud/Requests/IResultCollection.cs
+++ b/Turner.Infrastructure.Crud/Requests/IResultCollection.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Turner.Infrastructure.Crud.Requests
+{
+    public interface IResultCollection<TOut>
+    {
+        List<TOut> Items { get; set; }
+    }
+}

--- a/Turner.Infrastructure.Crud/Requests/MergeDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/MergeDefaultRequests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using AutoMapper;
 using Turner.Infrastructure.Crud.Configuration;
 using Turner.Infrastructure.Crud.Validation;
 
@@ -9,18 +8,22 @@ namespace Turner.Infrastructure.Crud.Requests
     public class MergeRequest<TEntity, TIn> : IMergeRequest<TEntity>
         where TEntity : class
     {
-        public MergeRequest(List<TIn> items) { Items = items; }
+        public List<TIn> Items { get; set; } = new List<TIn>();
 
-        public List<TIn> Items { get; }
+        public MergeRequest() { }
+
+        public MergeRequest(List<TIn> items) { Items = items; }
     }
     
     [MaybeValidate]
     public class MergeRequest<TEntity, TIn, TOut> : IMergeRequest<TEntity, TOut>
         where TEntity : class
     {
-        public MergeRequest(List<TIn> items) { Items = items; }
+        public List<TIn> Items { get; set; } = new List<TIn>();
 
-        public List<TIn> Items { get; }
+        public MergeRequest() { }
+
+        public MergeRequest(List<TIn> items) { Items = items; }
     }
 
     [MaybeValidate]

--- a/Turner.Infrastructure.Crud/Requests/MergeRequest.cs
+++ b/Turner.Infrastructure.Crud/Requests/MergeRequest.cs
@@ -19,9 +19,9 @@ namespace Turner.Infrastructure.Crud.Requests
     {
     }
 
-    public class MergeResult<TOut>
+    public class MergeResult<TOut> : IResultCollection<TOut>
     {
-        public List<TOut> Items { get; }
+        public List<TOut> Items { get; set; }
 
         public MergeResult(IEnumerable<TOut> items)
         {

--- a/Turner.Infrastructure.Crud/Requests/MergeRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/MergeRequestHandler.cs
@@ -126,10 +126,10 @@ namespace Turner.Infrastructure.Crud.Requests
         public async Task<MergeResult<TOut>> HandleAsync(TRequest request, CancellationToken token)
         {
             var entities = await MergeEntities(request, token).Configure();
-            var tOuts = await entities.CreateResults<TEntity, TOut>(RequestConfig, token).Configure();
-            var items = await request.RunResultHooks(RequestConfig, tOuts, token).Configure();
+            var items = await entities.CreateResults<TEntity, TOut>(RequestConfig, token).Configure();
+            var result = new MergeResult<TOut>(items);
 
-            return new MergeResult<TOut>(items);
+            return await request.RunResultHooks(RequestConfig, result, token).Configure();
         }
     }
 }

--- a/Turner.Infrastructure.Crud/Requests/PagedGetAllRequest.cs
+++ b/Turner.Infrastructure.Crud/Requests/PagedGetAllRequest.cs
@@ -14,9 +14,9 @@ namespace Turner.Infrastructure.Crud.Requests
     {
     }
 
-    public class PagedGetAllResult<TOut>
+    public class PagedGetAllResult<TOut> : IResultCollection<TOut>
     {
-        public List<TOut> Items { get; }
+        public List<TOut> Items { get; set; }
 
         public int PageNumber { get; }
 

--- a/Turner.Infrastructure.Crud/Requests/SaveDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/SaveDefaultRequests.cs
@@ -9,9 +9,11 @@ namespace Turner.Infrastructure.Crud.Requests
     public class SaveRequest<TEntity, TIn> : ISaveRequest<TEntity>
         where TEntity : class
     {
-        public SaveRequest(TIn item) { Item = item; }
+        public TIn Item { get; set; }
 
-        public TIn Item { get; }
+        public SaveRequest() { }
+
+        public SaveRequest(TIn item) { Item = item; }
     }
 
     public class SaveRequestProfile<TEntity, TIn>
@@ -30,9 +32,11 @@ namespace Turner.Infrastructure.Crud.Requests
     public class SaveRequest<TEntity, TIn, TOut> : ISaveRequest<TEntity, TOut>
         where TEntity : class
     {
-        public SaveRequest(TIn item) { Item = item; }
+        public TIn Item { get; set; }
 
-        public TIn Item { get; }
+        public SaveRequest() { }
+
+        public SaveRequest(TIn item) { Item = item; }
     }
 
     public class SaveRequestProfile<TEntity, TIn, TOut>
@@ -52,15 +56,17 @@ namespace Turner.Infrastructure.Crud.Requests
         : ISaveRequest<TEntity, TOut>
         where TEntity : class
     {
+        public TKey Key { get; set; }
+
+        public TIn Item { get; set; }
+
+        public SaveRequest() { }
+
         public SaveRequest(TKey key, TIn item)
         {
             Key = key;
             Item = item;
         }
-
-        public TKey Key { get; }
-
-        public TIn Item { get; }
     }
 
     public class SaveRequestProfile<TEntity, TKey, TIn, TOut>

--- a/Turner.Infrastructure.Crud/Requests/SynchronizeDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/SynchronizeDefaultRequests.cs
@@ -8,18 +8,18 @@ namespace Turner.Infrastructure.Crud.Requests
     public class SynchronizeRequest<TEntity, TIn> : ISynchronizeRequest<TEntity>
         where TEntity : class
     {
-        public SynchronizeRequest(List<TIn> items) { Items = items; }
+        public List<TIn> Items { get; set; } = new List<TIn>();
 
-        public List<TIn> Items { get; }
+        public SynchronizeRequest(List<TIn> items) { Items = items; }
     }
 
     [MaybeValidate]
     public class SynchronizeRequest<TEntity, TIn, TOut> : ISynchronizeRequest<TEntity, TOut>
         where TEntity : class
     {
-        public SynchronizeRequest(List<TIn> items) { Items = items; }
+        public List<TIn> Items { get; set; } = new List<TIn>();
 
-        public List<TIn> Items { get; }
+        public SynchronizeRequest(List<TIn> items) { Items = items; }
     }
 
     [MaybeValidate]

--- a/Turner.Infrastructure.Crud/Requests/SynchronizeRequest.cs
+++ b/Turner.Infrastructure.Crud/Requests/SynchronizeRequest.cs
@@ -19,9 +19,9 @@ namespace Turner.Infrastructure.Crud.Requests
     {
     }
 
-    public class SynchronizeResult<TOut>
+    public class SynchronizeResult<TOut> : IResultCollection<TOut>
     {
-        public List<TOut> Items { get; }
+        public List<TOut> Items { get; set; }
 
         public SynchronizeResult(IEnumerable<TOut> items)
         {

--- a/Turner.Infrastructure.Crud/Requests/SynchronizeRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/SynchronizeRequestHandler.cs
@@ -145,10 +145,10 @@ namespace Turner.Infrastructure.Crud.Requests
         public async Task<SynchronizeResult<TOut>> HandleAsync(TRequest request, CancellationToken token)
         {
             var entities = await SynchronizeEntities(request, token).Configure();
-            var tOuts = await entities.CreateResults<TEntity, TOut>(RequestConfig, token).Configure();
-            var items = await request.RunResultHooks(RequestConfig, tOuts, token).Configure();
+            var items = await entities.CreateResults<TEntity, TOut>(RequestConfig, token).Configure();
+            var result = new SynchronizeResult<TOut>(items);
 
-            return new SynchronizeResult<TOut>(items);
+            return await request.RunResultHooks(RequestConfig, result, token).Configure();
         }
     }
 }

--- a/Turner.Infrastructure.Crud/Requests/UniversalRequestDecorator.cs
+++ b/Turner.Infrastructure.Crud/Requests/UniversalRequestDecorator.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Turner.Infrastructure.Crud.Configuration;
+using Turner.Infrastructure.Mediator;
+
+namespace Turner.Infrastructure.Crud.Requests
+{
+    public class UniversalRequestDecorator<TRequest>
+        : IRequestHandler<TRequest>
+        where TRequest : IRequest
+    {
+        private readonly ICrudRequestConfig _requestConfig;
+        private readonly Func<IRequestHandler<TRequest>> _decorateeFactory;
+
+        public UniversalRequestDecorator(CrudConfigManager profileManager,
+            Func<IRequestHandler<TRequest>> decorateeFactory)
+        {
+            _decorateeFactory = decorateeFactory;
+            _requestConfig = profileManager.GetRequestConfigFor<TRequest>();
+        }
+
+        public async Task<Response> HandleAsync(TRequest request)
+        {
+            using (var cts = new CancellationTokenSource())
+            {
+                var token = cts.Token;
+
+                foreach (var requestHook in _requestConfig.GetRequestHooks())
+                {
+                    await requestHook.Run(request, token).Configure();
+                    token.ThrowIfCancellationRequested();
+                }
+
+                return await _decorateeFactory().HandleAsync(request);
+            }
+        }
+    }
+
+    public class UniversalRequestDecorator<TRequest, TResult>
+        : IRequestHandler<TRequest, TResult>
+        where TRequest : IRequest<TResult>
+    {
+        private readonly ICrudRequestConfig _requestConfig;
+        private readonly Func<IRequestHandler<TRequest, TResult>> _decorateeFactory;
+
+        public UniversalRequestDecorator(CrudConfigManager profileManager,
+            Func<IRequestHandler<TRequest, TResult>> decorateeFactory)
+        {
+            _decorateeFactory = decorateeFactory;
+            _requestConfig = profileManager.GetRequestConfigFor<TRequest>();
+        }
+
+        public async Task<Response<TResult>> HandleAsync(TRequest request)
+        {
+            using (var cts = new CancellationTokenSource())
+            {
+                var token = cts.Token;
+
+                foreach (var requestHook in _requestConfig.GetRequestHooks())
+                {
+                    await requestHook.Run(request, token).Configure();
+                    token.ThrowIfCancellationRequested();
+                }
+
+                var response = await _decorateeFactory().HandleAsync(request);
+
+                if (response.HasErrors)
+                    return response;
+
+                var result = response.Data;
+
+                foreach (var hook in _requestConfig.GetResultHooks())
+                {
+                    if (typeof(TResult).IsAssignableFrom(hook.ResultType))
+                        result = (TResult)await hook.Run(request, result, token).Configure();
+                    else
+                        result = await ResultHookAdapter.Adapt(hook, request, result, token).Configure();
+
+                    token.ThrowIfCancellationRequested();
+                }
+
+                return result.AsResponse();
+            }
+        }
+    }
+}

--- a/Turner.Infrastructure.Crud/Requests/UpdateAllDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/UpdateAllDefaultRequests.cs
@@ -8,18 +8,18 @@ namespace Turner.Infrastructure.Crud.Requests
     public class UpdateAllRequest<TEntity, TIn> : IUpdateAllRequest<TEntity>
         where TEntity : class
     {
-        public UpdateAllRequest(List<TIn> items) { Items = items; }
+        public List<TIn> Items { get; set; }
 
-        public List<TIn> Items { get; }
+        public UpdateAllRequest(List<TIn> items) { Items = items; }
     }
 
     [MaybeValidate]
     public class UpdateAllRequest<TEntity, TIn, TOut> : IUpdateAllRequest<TEntity, TOut>
         where TEntity : class
     {
-        public UpdateAllRequest(List<TIn> items) { Items = items; }
+        public List<TIn> Items { get; set; }
 
-        public List<TIn> Items { get; }
+        public UpdateAllRequest(List<TIn> items) { Items = items; }
     }
     
     [MaybeValidate]

--- a/Turner.Infrastructure.Crud/Requests/UpdateAllRequest.cs
+++ b/Turner.Infrastructure.Crud/Requests/UpdateAllRequest.cs
@@ -19,9 +19,9 @@ namespace Turner.Infrastructure.Crud.Requests
     {
     }
 
-    public class UpdateAllResult<TOut>
+    public class UpdateAllResult<TOut> : IResultCollection<TOut>
     {
-        public List<TOut> Items { get; }
+        public List<TOut> Items { get; set; }
 
         public UpdateAllResult(IEnumerable<TOut> items)
         {

--- a/Turner.Infrastructure.Crud/Requests/UpdateAllRequestHandler.cs
+++ b/Turner.Infrastructure.Crud/Requests/UpdateAllRequestHandler.cs
@@ -93,10 +93,10 @@ namespace Turner.Infrastructure.Crud.Requests
         public async Task<UpdateAllResult<TOut>> HandleAsync(TRequest request, CancellationToken token)
         {
             var entities = await UpdateEntities(request, token).Configure();
-            var tOuts = await entities.CreateResults<TEntity, TOut>(RequestConfig, token).Configure();
-            var items = await request.RunResultHooks(RequestConfig, tOuts, token).Configure();
+            var items = await entities.CreateResults<TEntity, TOut>(RequestConfig, token).Configure();
+            var result = new UpdateAllResult<TOut>(items);
 
-            return new UpdateAllResult<TOut>(items);
+            return await request.RunResultHooks(RequestConfig, result, token).Configure();
         }
     }
 }

--- a/Turner.Infrastructure.Crud/Requests/UpdateDefaultRequests.cs
+++ b/Turner.Infrastructure.Crud/Requests/UpdateDefaultRequests.cs
@@ -9,9 +9,9 @@ namespace Turner.Infrastructure.Crud.Requests
     public class UpdateRequest<TEntity, TIn> : IUpdateRequest<TEntity>
         where TEntity : class
     {
-        public UpdateRequest(TIn item) { Item = item; }
+        public TIn Item { get; set; }
 
-        public TIn Item { get; }
+        public UpdateRequest(TIn item) { Item = item; }
     }
 
     public class UpdateRequestProfile<TEntity, TIn>
@@ -29,9 +29,9 @@ namespace Turner.Infrastructure.Crud.Requests
     public class UpdateRequest<TEntity, TIn, TOut> : IUpdateRequest<TEntity, TOut>
         where TEntity : class
     {
-        public UpdateRequest(TIn item) { Item = item; }
+        public TIn Item { get; set; }
 
-        public TIn Item { get; }
+        public UpdateRequest(TIn item) { Item = item; }
     }
 
     public class UpdateRequestProfile<TEntity, TIn, TOut>
@@ -50,9 +50,9 @@ namespace Turner.Infrastructure.Crud.Requests
         : IUpdateRequest<TEntity, TOut>
         where TEntity : class
     {
-        public TKey Key { get; }
+        public TKey Key { get; set; }
 
-        public TIn Item { get; }
+        public TIn Item { get; set; }
 
         public UpdateRequest(TKey key, TIn item)
         {


### PR DESCRIPTION
- Added "universal" request profiles for non-Crud requests
  - non-Crud `IRequest`/`IRequest<T>` types may now have request and result hooks applied to them
- Added result hook type adapter so that result hooks can operate on `T` or collections of `T`
- Added setters to the default request properties
- Added default contructors to the default requests