### PR TITLE
feat(invalid sort handling): added logic for handling bad sort requests

### DIFF
--- a/Turner.Infrastructure.Crud/Components/Sort/BasicSorter.cs
+++ b/Turner.Infrastructure.Crud/Components/Sort/BasicSorter.cs
@@ -41,8 +41,7 @@ namespace Turner.Infrastructure.Crud
 
         public IOrderedQueryable<TEntity> Sort(TRequest request, IQueryable<TEntity> queryable)
         {
-            if (_firstSortFunc == null ||
-                (_predicate != null && !_predicate(request)))
+            if (_firstSortFunc == null || (_predicate != null && !_predicate(request)))
                 return null;
             
             var result = _firstSortFunc(queryable) as IOrderedQueryable<TEntity>;
@@ -66,14 +65,16 @@ namespace Turner.Infrastructure.Crud
         
         public IOrderedQueryable<TEntity> Sort(TRequest request, IQueryable<TEntity> queryable)
         {
+            IOrderedQueryable<TEntity> result;
+
             foreach (var operation in _operations)
             {
-                var result = operation.Sort(request, queryable);
+                result = operation.Sort(request, queryable);
                 if (result != null)
                     return result;
             }
-
-            return null;
+            
+            return queryable as IOrderedQueryable<TEntity>;
         }
     }
 }

--- a/Turner.Infrastructure.Crud/Components/Sort/SwitchSorter.cs
+++ b/Turner.Infrastructure.Crud/Components/Sort/SwitchSorter.cs
@@ -47,8 +47,8 @@ namespace Turner.Infrastructure.Crud
 
             if (_default != null)
                 return _default.Sort(request, queryable);
-
-            return null;
+            
+            return _cases.Values.First().Sort(request, queryable);
         }
     }
 }

--- a/Turner.Infrastructure.Crud/Configuration/Builders/Sort/BasicSortBuilder.cs
+++ b/Turner.Infrastructure.Crud/Configuration/Builders/Sort/BasicSortBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Turner.Infrastructure.Crud.Exceptions;
 
 namespace Turner.Infrastructure.Crud.Configuration.Builders.Sort
 {
@@ -34,6 +35,13 @@ namespace Turner.Infrastructure.Crud.Configuration.Builders.Sort
 
         internal override ISorterFactory Build()
         {
+            if (_operations.Count == 0)
+            {
+                throw new BadCrudConfigurationException(
+                    $"Basic sorting was set for request '{typeof(TRequest)}' and entity '{typeof(TEntity)}'" +
+                    ", but no sort operation was defined.");
+            }
+
             var instance = new BasicSorter<TRequest, TEntity>(_operations.Select(builder => builder.Build()).ToList());
 
             return InstanceSorterFactory.From(instance);

--- a/Turner.Infrastructure.Crud/Configuration/Builders/Sort/SwitchSortBuilder.cs
+++ b/Turner.Infrastructure.Crud/Configuration/Builders/Sort/SwitchSortBuilder.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
+using Turner.Infrastructure.Crud.Exceptions;
 using Turner.Infrastructure.Crud.Extensions;
 
 namespace Turner.Infrastructure.Crud.Configuration.Builders.Sort
@@ -51,6 +52,13 @@ namespace Turner.Infrastructure.Crud.Configuration.Builders.Sort
 
             if (_default != null)
                 sorter.Default(_default.Build());
+
+            if (_default == null && _cases.Count == 0)
+            {
+                throw new BadCrudConfigurationException(
+                    $"Switch sorting was set for request '{typeof(TRequest)}' and entity '{typeof(TEntity)}'" +
+                    ", but no cases were defined.");
+            }
 
             return InstanceSorterFactory.From(sorter);
         }


### PR DESCRIPTION
- Added requirement to specify at least one switch case or the default case for switch sorting
  - If the switch value is null or invalid and the default case is not specified, the first defined case will be used
- Added ability to specify the default table column for table sorting
- Added requirement to specify at least one table column for table sorting
  - If the table column value is null or invalid and the default column is not specified, the first defined column will be used